### PR TITLE
Dnsenum tool installed

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -101,6 +101,11 @@
             "name": "enum4linux",
             "cmd": "enum4linux",
             "args": true
+          },
+          {
+            "name": "dnsenum",
+            "cmd": "dnsenum",
+            "args": true
           }
         ]
       },

--- a/src/components/DNSenumTool/DNSenumTool.tsx
+++ b/src/components/DNSenumTool/DNSenumTool.tsx
@@ -1,0 +1,69 @@
+import { Button, LoadingOverlay, Stack, TextInput, Title } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useCallback, useState } from "react";
+import { CommandHelper } from "../../utils/CommandHelper";
+import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
+
+interface FormValuesType {
+    domain: string;
+    subdomains: string;
+    threads: number;
+}
+
+const DnsenumTool = () => {
+    const [loading, setLoading] = useState(false);
+    const [output, setOutput] = useState("");
+
+    let form = useForm({
+        initialValues: {
+            domain: "",
+            subdomains: "",
+            threads: 10,
+        },
+    });
+
+    const onSubmit = async (values: FormValuesType) => {
+        setLoading(true);
+        const args = [
+            "--enum",
+            "--threads",
+            `${values.threads}`,
+            `${values.domain}`,
+            "-o",
+            "dnsenum.txt",
+        ];
+
+        if (values.subdomains) {
+            args.push(`-S ${values.subdomains}`);
+        }
+
+        try {
+            const output = await CommandHelper.runCommand("dnsenum", args);
+            setOutput(output);
+        } catch (e: any) {
+            setOutput(e);
+        }
+
+        setLoading(false);
+    };
+
+    const clearOutput = useCallback(() => {
+        setOutput("");
+    }, [setOutput]);
+
+    return (
+        <form onSubmit={form.onSubmit(onSubmit)}>
+            <LoadingOverlay visible={loading} />
+            <Stack>
+                <Title>DNS Enumeration (dnsenum)</Title>
+                <TextInput label={"Domain"} required {...form.getInputProps("domain")} />
+                <TextInput label={"Subdomains to include (comma-separated)"} {...form.getInputProps("subdomains")} />
+                <TextInput label={"Threads"} type="number" min={1} {...form.getInputProps("threads")} />
+                <Button type={"submit"}>Start Enumeration</Button>
+                <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
+            </Stack>
+        </form>
+    );
+};
+
+export default DnsenumTool;

--- a/src/components/DNSenumTool/DNSenumTool.tsx
+++ b/src/components/DNSenumTool/DNSenumTool.tsx
@@ -29,8 +29,6 @@ const DnsenumTool = () => {
             "--threads",
             `${values.threads}`,
             `${values.domain}`,
-            "-o",
-            "dnsenum.txt",
         ];
 
         if (values.subdomains) {

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -22,6 +22,7 @@ import ARPSpoofing from "./ArpSpoof/ArpSpoof";
 import WalkthroughSamplePage from "./WalkthroughPages/WalkthroughSamplePage";
 import { CVE202224112 } from "./CVE-2022-24112/CVE-2022-24112";
 import Enum4Linux from "./Enum4Linux/Enum4Linux";
+import DnsenumTool from "./DNSenumTool/DNSenumTool";
 
 export interface RouteProperties {
     name: string;
@@ -138,6 +139,12 @@ export const ROUTES: RouteProperties[] = [
         path: "/tools/Hydra",
         element: <Hydra />,
         description: "Login Cracker",
+    },
+    {
+        name: "DNSenum",
+        path: "/tools/dnsenum",
+        element: <DnsenumTool />,
+        description: "DNS enumeration tool",
     },
     {
         name: "Urlsnarf",


### PR DESCRIPTION
branch contains implemented DNSenumTool.ts file under the path src/components/DNSenumTool. Tool should operate correctly with the GUI, return enumerated dns information on target domain. option available to increase or decrease the thread count of the attack (can speed up attack, at the cost of being more visible to security programs). changes also made in RouteWrapper.tsx and tauri.conf.json to allow the tool to run.