### PR TITLE
Netcat tool implementation

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -141,6 +141,16 @@
                         "name": "cewl",
                         "cmd": "cewl",
                         "args": true
+                    },
+                    { 
+                        "name": "nc", 
+                        "cmd": "nc",
+                        "args": true
+                    },
+                    {
+                        "name": "bash", 
+                        "cmd": "bash",
+                        "args": true
                     }
                 ]
             },

--- a/src/components/Netcat/Netcat.tsx
+++ b/src/components/Netcat/Netcat.tsx
@@ -1,0 +1,170 @@
+import { Button, LoadingOverlay, NativeSelect, Stack, TextInput } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useCallback, useState } from "react";
+import { CommandHelper } from "../../utils/CommandHelper";
+import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
+import { UserGuide } from "../UserGuide/UserGuide";
+
+const title = "Netcat Tool";
+const description_userguide =
+    "Netcat is a powerful tool that is used to connect two machines together for communication and for other uses.\n" +
+    "How to use this netcat tool:\n" +
+    "- If you want to listen for connections for chat or reverse shell choose the Interactive shell/Listen option and provide \n a port number.\n" +
+    "- If you want to scan for ports, provide an IP address and a port range\n" +
+    "- If you want to send a file, provide the destination IP address, Port number, and File name\n" +
+    "- If you want to receive a file, provide a port number and the File name.\n" +
+    "- If you want to port scan a domain, provide Domain name and a Port number. \n" +
+    "Note: You should only use website port scan to a domain that you own.\n" +
+    "Note 2: Using the sending/receiving file option might seem like it is not working, but it is working.\n" +
+    "You will need a second machine to see the file transfer\n" +
+    "For more information go to the reference page and click on netcat, alternatively Google is your friend.";
+
+//Variables
+interface FormValuesType {
+    ipAddress: string;
+    portNumber: string;
+    netcatOptions: string;
+    websiteUrl: string;
+    filePath: string;
+}
+
+//Netcat Options
+const netcatOptions = [
+    "Port Scan",
+    "Send File",
+    "Receive File",
+    "Website Port scan",
+    "Interactive terminal/Listen (for chat or reverse shell) [Beta]",
+];
+
+//Tool name must be capital or jsx will cry out errors :P
+const NetcatTool = () => {
+    const [loading, setLoading] = useState(false);
+    var [output, setOutput] = useState("");
+    const [selectedScanOption, setSelectedNetcatOption] = useState("");
+
+    let form = useForm({
+        initialValues: {
+            ipAddress: "",
+            portNumber: "",
+            netcatOptions: "",
+            websiteUrl: "",
+            filePath: "",
+        },
+    });
+
+    const onSubmit = async (values: FormValuesType) => {
+        setLoading(false);
+
+        //Starts off with the IP address after netcat
+        //Ex: nc <ip address>
+        let args = [``];
+
+        //Switch case
+        switch (values.netcatOptions) {
+            case "Port Scan": //nc syntax: nc -zv <ip address/hostname> <port range>
+                args = [`-zv`];
+                args.push(`${values.ipAddress}`);
+                args.push(`${values.portNumber}`);
+
+                try {
+                    let output = await CommandHelper.runCommand("nc", args);
+                    setOutput(output);
+                } catch (e: any) {
+                    setOutput(e);
+                }
+
+                break;
+
+            case "Send File": //Sends file from attacker to victim, syntax: nc -w 15 <Dest IP address> <Port number> < <FileName>
+                args = [`-w 15`]; //I set the timeout on 15 by default, you can remove it if you want
+                args.push(`${values.ipAddress} ${values.portNumber} < ${values.filePath}`);
+
+                try {
+                    let output = await CommandHelper.runCommand("nc", args);
+                    setOutput(output);
+                } catch (e: any) {
+                    setOutput(e);
+                }
+
+                break;
+
+            case "Receive File": //Receives file from victim to attacker, syntax: nc -l <port number> > filename.file
+                args = [`-lp`];
+                args.push(`${values.portNumber} > ${values.filePath}`);
+
+                try {
+                    let output = await CommandHelper.runCommand("nc", args);
+                    setOutput(output);
+                } catch (e: any) {
+                    setOutput(e);
+                }
+
+                break;
+
+            case "Website Port scan": //Scans a website for ports, syntax: nc -zv <hostname> <port range>
+                args = [`-zv`]; //PLease only use website portscan on a website/Domain that you own
+                args.push(`${values.websiteUrl}`);
+                args.push(`${values.portNumber}`);
+
+                try {
+                    let output = await CommandHelper.runCommand("nc", args);
+                    setOutput(output);
+                } catch (e: any) {
+                    setOutput(e);
+                }
+
+                break;
+
+            case "Interactive terminal/Listen (for chat or reverse shell) [Beta]":
+                //Beta stage
+                //The script executes a separate qterminal session that runs netcat listen command
+                //The script runs like the normal netcat listen where the user can communicate between the attacker (kali) and the victim (VM2)
+                //Not sure how to add output to the tool
+                args = [`/usr/share/ddt/netcatTerminal.sh`];
+                args.push(`${values.portNumber}`);
+
+                try {
+                    let output = await CommandHelper.runCommand("bash", args);
+                    setOutput(output);
+                } catch (e: any) {
+                    setOutput(e);
+                }
+
+                break;
+        }
+
+        setLoading(false);
+    };
+
+    const clearOutput = useCallback(() => {
+        setOutput("");
+    }, [setOutput]);
+
+    //<ConsoleWrapper output={output} clearOutputCallback={clearOutput} /> prints the terminal on the tool
+    return (
+        <form onSubmit={form.onSubmit((values) => onSubmit({ ...values, netcatOptions: selectedScanOption }))}>
+            <LoadingOverlay visible={loading} />
+            <Stack>
+                {UserGuide(title, description_userguide)}
+                <TextInput label={"IP address"} {...form.getInputProps("ipAddress")} />
+                <TextInput label={"Port number/Port range"} required {...form.getInputProps("portNumber")} />
+                <TextInput label={"File path"} {...form.getInputProps("filePath")} />
+                <TextInput label={"Domain name"} {...form.getInputProps("websiteUrl")} />
+                <NativeSelect
+                    value={selectedScanOption}
+                    onChange={(e) => setSelectedNetcatOption(e.target.value)}
+                    title={"Netcat option"}
+                    data={netcatOptions}
+                    required
+                    placeholder={"Pick a scan option"}
+                    description={"Type of scan to perform"}
+                />
+                <Button type={"submit"}>start netcat</Button>
+                <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
+            </Stack>
+        </form>
+    );
+};
+
+export default NetcatTool;

--- a/src/components/Netcat/netcatTerminal.sh
+++ b/src/components/Netcat/netcatTerminal.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#Output=/home/kali/Desktop/TestFile.txt
+PortNumber=$1
+
+netcatListen(){
+    #qterminal -e nc -lvp $PortNumber 1> $Output 2>&1, commented out since its not working at the moment
+    qterminal -e nc -lvp $PortNumber
+}
+
+netcatListen
+
+#Terminal works, not sure why the output isnt showing
+#PortNumber is the portnumber passed from Netcat.tsx file
+#Output is a test file where I planned to save the output of the function (not working at the moment)
+
+

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -25,6 +25,7 @@ import DnsenumTool from "./DNSenumTool/DNSenumTool";
 import DNSMap from "./DNSMap/DNSMap";
 import Gyoithon from "./Gyoithon/Gyoithon";
 import Cewl from "./Cewl/Cewl";
+import NetcatTool from "./Netcat/Netcat";
 
 export interface RouteProperties {
     name: string;
@@ -201,6 +202,12 @@ export const ROUTES: RouteProperties[] = [
         path: "/tools/Cewl",
         element: <Cewl />,
         description: "Custom word list generator",
+    },
+    {
+        name: "Netcat",
+        path: "/tools/Netcat",
+        element: <NetcatTool />,
+        description: "Netcat",
     },
 ];
 

--- a/src/pages/References.tsx
+++ b/src/pages/References.tsx
@@ -111,6 +111,13 @@ const ReferencesPage = () => {
                         description={"CeWL (Custom Word List generator) is a ruby app which spiders a given URL."}
                         url={"https://www.kali.org/tools/cewl/"}
                     />
+                    <Reference
+                        name={"Netcat"}
+                        description={
+                            "Netcat is a UNIX tool that reads and writes data across network connections using TCP and UDP protocols."
+                        }
+                        url={"https://www.kali.org/tools/netcat/"}
+                    />
                     <Title order={4}>Attack Vectors:</Title>
                     <Reference
                         name={"CVE-2022-24112"}


### PR DESCRIPTION
Changes:
- Added Netcat tool into DDT (Netcat.tsx)
- Netcat tool can:
   - Listen (for reverse shell/Chat, still on its beta stage)
   - Port scan
   - Port scan hostnames
   - Send files
   - Receive files
- Added Netcat command and bash command to the configuration file
- Added Netcat route to the routewrapper file
- Added "netcatTerminal" bash script to enable interactive terminal for the use 
- Added Netcat to the reference page
- Added a quick user guide to the Netcat tool