### PR TITLE
fixing absence of Sherlock from install_dependencies.sh

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -46,7 +46,8 @@ sudo apt install -y mitmproxy \
 		goldeneye \
 		wpscan \
 		parsero \
-		arjun
+		arjun \
+		sherlock
 
 echo "-----------------------------"
 echo "Installing yarn..."


### PR DESCRIPTION
Sherlock was not being installed due to its absence from the install_dependencies.sh file. This pull request rectifies that oversight.