### PR TITLE
Resolving dependency script execution error

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -2,42 +2,29 @@
 
 echo "----------------------------------------"
 echo "Starting installation of dependencies..."
-echo "Installing NodeSource NodeJS..."
+#echo "Installing NodeSource NodeJS..."
 echo "----------------------------------------"
 #Install NodeSource NodeJS
-sudo su <<E0F 
-curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-exit
-E0F
+#sudo su <<E0F 
+#curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+#exit
+#E0F
 
-echo "---------------------------------------"
-echo "NodeSource NodeJS installation complete"
-echo "Installing APT packages"
-echo "---------------------------------------"
-# Update all packages.
-sudo apt update
-sudo apt upgrade -y
+#echo "---------------------------------------"
+#echo "NodeSource NodeJS installation complete"
+#echo "Installing APT packages"
+#echo "---------------------------------------"
 
-# Install tauri deps.
-sudo apt install -y libwebkit2gtk-4.0-dev \
-    	build-essential \
-    	curl \
-    	wget \
-    	libssl-dev \
-    	libgtk-3-dev \
-    	libayatana-appindicator3-dev \
-    	librsvg2-dev \
-    	python3-impacket
-
-# Installing missing deps from kali...
-sudo apt install -y mitmproxy \
+# Installing tauri deps and missing deps from kali...
+sudo apt install -y python3-impacket \
+		mitmproxy \
         libglib2.0-dev \
         libsoup2.4-dev \
         libjavascriptcoregtk-4.0-18 \
         libjavascriptcoregtk-4.0-dev \
         libwebkit2gtk-4.1-0 \
         libwebkit2gtk-4.1-dev \
-		openjdk-11-jdk
+		openjdk-11-jdk \
 		cargo \
 		nodejs \
 		dsniff \
@@ -49,16 +36,16 @@ sudo apt install -y mitmproxy \
 		arjun \
 		sherlock
 
-echo "-----------------------------"
-echo "Installing yarn..."
-echo "-----------------------------"
+#echo "-----------------------------"
+#echo "Installing yarn..."
+#echo "-----------------------------"
 # Install yarn.
-npm install -g yarn
+#npm install -g yarn
 
-echo "----------------------------------"
-echo "Yarn install complete"
-echo "Installing project dependencies..."
-echo "----------------------------------"
+#echo "----------------------------------"
+#echo "Yarn install complete"
+#echo "Installing project dependencies..."
+#echo "----------------------------------"
 
 # Install all yarn deps.
 yarn install

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "private": true,
     "version": "0.1.1",
     "scripts": {
+        "install": "bash install_dependencies.sh",
         "dev": "vite",
         "build": "tsc && vite build",
         "preview": "vite preview",


### PR DESCRIPTION
Further tweaks to install_dependencies.sh and package.json so that required tools like sherlock, parsero and others will be installed  with the rest of DDT. Modifications to the install instructions are also required, so "yarn run install" will be executed by the user rather than "yarn install"