### PR TITLE
Update NmapTool.tsx

### DIFF
--- a/src/components/NmapTool/NmapTool.tsx
+++ b/src/components/NmapTool/NmapTool.tsx
@@ -29,24 +29,26 @@ interface FormValuesType {
     numTopPorts: number;
     exclusion: string;
     verbose: boolean;
+    ipv6: boolean;
 }
 
 const speeds = ["T0", "T1", "T2", "T3", "T4", "T5"];
 
 const scanOptions = [
-    "All",
+    "Default",
     "Operating System",
     "Firewall Status",
     "Services",
     "Stealth",
     "Device Discovery",
+    "Aggressive",
     "Top ports",
 ];
 
 const NmapTool = () => {
     const [loading, setLoading] = useState(false);
     const [output, setOutput] = useState("");
-    //const [checkedAdvanced, setCheckedAdvanced] = useState(false);
+    const [checkedAdvanced, setCheckedAdvanced] = useState(false);
     const [selectedScanOption, setSelectedScanOption] = useState("");
     const [selectedSpeedOption, setSelectedSpeedOption] = useState("");
     const [verbose, setVerbose] = useState(false);
@@ -60,6 +62,7 @@ const NmapTool = () => {
             numTopPorts: 100,
             exclusion: "",
             verbose: false,
+            ipv6: false,
         },
     });
 
@@ -75,8 +78,14 @@ const NmapTool = () => {
             args.push("-v");
         }
 
-        if (values.scanOption === "All") {
-            args.push("-A");
+        /*if (values.scanOption === "All") {
+            args.push("-A -O -sA -sV -sN -sn");
+        } 
+            Previous "all" option was actually an aggressive scan. Looking to implement a functional 
+            all option but will need to look into necessary iputs
+        */
+        if (values.scanOption === "Default") {
+            args.push("");
         } else if (values.scanOption === "Operating System") {
             args.push("-O");
         } else if (values.scanOption === "Firewall Status") {
@@ -91,6 +100,10 @@ const NmapTool = () => {
             args.push("-A");
         } else if (values.scanOption === "Top ports") {
             args.push("--top-ports", `${values.numTopPorts}`);
+        }
+
+        if (values.ipv6) {
+            args.push("-6");
         }
 
         args.push(...values.ip.split(" "));
@@ -126,18 +139,24 @@ const NmapTool = () => {
             <Stack>
                 {UserGuide(title, description_userguide)}
 
-                {/* <Switch size="md"label="Advanced Mode" checked={checkedAdvanced}
-                    onChange={ (e) => setCheckedAdvanced(e.currentTarget.checked)}
-                    /> */}
+                <Switch
+                    size="md"
+                    label="Advanced Mode"
+                    checked={checkedAdvanced}
+                    onChange={(e) => setCheckedAdvanced(e.currentTarget.checked)}
+                />
                 <TextInput label={"IP or Hostname"} required {...form.getInputProps("ip")} />
-                {/* {checkedAdvanced && (
-<>
-<TextInput label={"Exclusions to range"} placeholder={"Form of xxx.xxx.xxx.xxx"}
-                    {...form.getInputProps("exclusion" )}/>            
-
-                )} */}
-                <Checkbox label={"Verbose"} {...form.getInputProps("verbose" as keyof FormValuesType)} />
-
+                {checkedAdvanced && (
+                    <>
+                        <TextInput
+                            label={"Exclusions to range"}
+                            placeholder={"Form of xxx.xxx.xxx.xxx"}
+                            {...form.getInputProps("exclusion")}
+                        />
+                        <Checkbox label={"Verbose"} {...form.getInputProps("verbose" as keyof FormValuesType)} />
+                        <Checkbox label={"IPv6"} {...form.getInputProps("ipv6" as keyof FormValuesType)} />
+                    </>
+                )}
                 {!isTopPortScan && <TextInput label={"Port"} {...form.getInputProps("port")} />}
                 {isTopPortScan && <NumberInput label={"Number of top ports"} {...form.getInputProps("numTopPorts")} />}
                 <NativeSelect


### PR DESCRIPTION
Added "Advanced Mode" switch to hide/display options in the GUI menu. Including: IP range exclusions
Verbose mode
IPv6 Address mode

Also added functionality for multiple IP addresses to be entered into the Address field.

Added "Default" scan type, to allow users to perform a simple NMAP scan without flag options.