### PR TITLE
ver 2 SaveOutput fixes multiple save file bug

### DIFF
--- a/src/components/NmapTool/NmapTool.tsx
+++ b/src/components/NmapTool/NmapTool.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from "react";
 import { CommandHelper } from "../../utils/CommandHelper";
 import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
 import { UserGuide } from "../UserGuide/UserGuide";
-import { SaveOutputToTextFile } from "../SaveOutputToFile/SaveOutputToTextFile";
+import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile";
 import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
 
 const title = "Network port scanner (NMAP)";
@@ -55,6 +55,8 @@ const NmapTool = () => {
     const [selectedSpeedOption, setSelectedSpeedOption] = useState("");
     const [verbose, setVerbose] = useState(false);
     const [pid, setPid] = useState("");
+    const [allowSave, setAllowSave] = useState(false);
+    const [hasSaved, setHasSaved] = useState(false);
 
     let form = useForm({
         initialValues: {
@@ -91,6 +93,10 @@ const NmapTool = () => {
             setPid("");
             // Cancel the Loading Overlay
             setLoading(false);
+
+            // Allow Saving as the output is finalised
+            setAllowSave(true);
+            setHasSaved(false);
         },
         [handleProcessData]
     );
@@ -103,7 +109,18 @@ const NmapTool = () => {
     //    }
     //};
 
+    // Actions taken after saving the output
+    const handleSaveComplete = () => {
+        // Indicating that the file has saved which is passed
+        // back into SaveOutputToTextFile to inform the user
+        setHasSaved(true);
+        setAllowSave(false);
+    };
+
     const onSubmit = async (values: FormValuesType) => {
+        // Disallow saving until the tool's execution is complete
+        setAllowSave(false);
+
         // Start the Loading Overlay
         setLoading(true);
 
@@ -166,6 +183,8 @@ const NmapTool = () => {
 
     const clearOutput = useCallback(() => {
         setOutput("");
+        setHasSaved(false);
+        setAllowSave(false);
     }, [setOutput]);
 
     // Determine if the current scan options are for the top ports.
@@ -218,7 +237,7 @@ const NmapTool = () => {
                     placeholder={"Pick a scan option"}
                     description={"Type of scan to perform"}
                 />
-                {SaveOutputToTextFile(output)}
+                {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
                 <Button type={"submit"}>Scan</Button>
                 <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
             </Stack>

--- a/src/components/SaveOutputToFile/SaveOutputToTextFile.tsx
+++ b/src/components/SaveOutputToFile/SaveOutputToTextFile.tsx
@@ -1,4 +1,4 @@
-import { TextInput, Checkbox } from "@mantine/core";
+import { TextInput, Checkbox, Button } from "@mantine/core";
 import { BaseDirectory, writeTextFile, createDir } from "@tauri-apps/api/fs";
 import { useState } from "react";
 
@@ -31,6 +31,53 @@ export function SaveOutputToTextFile(outputToSave: string) {
                     value={filename}
                     onChange={handleFilenameChange}
                 />
+            )}
+        </>
+    );
+}
+
+export function SaveOutputToTextFile_v2(
+    outputToSave: string,
+    allowSave: boolean,
+    hasSaved: boolean,
+    onSave: () => void
+) {
+    const [filename, setFilename] = useState("");
+
+    const handleFilenameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const newFilename = e.currentTarget.value;
+        setFilename(newFilename);
+    };
+
+    const handleSave = () => {
+        if (outputToSave && filename && allowSave) {
+            const outputDir = `./Deakin-Detonator-Toolkit/OutputFiles/`;
+            createDir(outputDir, { dir: BaseDirectory.Home, recursive: true });
+            writeTextFile(outputDir + filename, outputToSave, { dir: BaseDirectory.Home });
+            onSave(); // Call the onSave callback to perform post save actions in caller
+        }
+    };
+
+    return (
+        <>
+            {allowSave && (
+                <>
+                    <TextInput
+                        label={"Output filename"}
+                        placeholder={"output.txt"}
+                        value={filename}
+                        onChange={handleFilenameChange}
+                    />
+                    <Button type={"button"} onClick={handleSave}>
+                        Save Output To File
+                    </Button>
+                </>
+            )}
+            {hasSaved && (
+                <div className="save-message">
+                    Output has been saved! <br />
+                    Output save file: /Deakin-Detonator-Toolkit/OutputFiles/{filename}
+                </div>
             )}
         </>
     );


### PR DESCRIPTION
Adds SaveOutputToTextFilev_v2() to SaveOutputToTextFile.tsx. 

This fixes the mulitple save file bug and makes other improvements like informing the user about a successful save. 

This will be rolled out to all existing implementations soon. Once fully replaced SaveOutputToTextFile will be deprecated, and SaveOutputToTextFile_v2 will be renamed as SaveOutputToTextFile and all references will be altered. 

Includes an initial implementation in Nmap.