### PR TITLE
implement pkexec, solve elavated priviliges issue, implemented airbas…

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,6 +18,11 @@
                 "sidecar": true,
                 "scope": [
                     {
+                        "name": "pkexec",
+                        "cmd": "pkexec",
+                        "args": true
+                    },
+                    {
                         "name": "nmap",
                         "cmd": "nmap",
                         "args": true
@@ -258,6 +263,11 @@
                         "args": true
                     },
                     {
+                        "name": "airbase-ng",
+                        "cmd": "airbase-ng",
+                        "args": true
+                    },
+                    {
                         "name": "wpscan",
                         "cmd": "wpscan",
                         "args": true
@@ -273,6 +283,7 @@
                         "cmd": "rcrack",
                         "args": true
                     }
+
                 ]
             },
             "fs": {

--- a/src/components/AirbaseNG/AirbaseNG.tsx
+++ b/src/components/AirbaseNG/AirbaseNG.tsx
@@ -1,0 +1,133 @@
+import { Button, Stack, TextInput } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useCallback, useState } from "react";
+import { CommandHelper } from "../../utils/CommandHelper";
+import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
+import { UserGuide } from "../UserGuide/UserGuide";
+import { SaveOutputToTextFile } from "../SaveOutputToFile/SaveOutputToTextFile";
+import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
+
+/**
+ * TODO:
+ * 1. Refine the user interface for better usability and integrate a mechanism for file selection from the local machine.
+ * 2. Introduce an 'Advanced Mode' for users familiar with the nuances of the tool.
+ * 3. Gradually expand input options in 'Advanced Mode' with the eventual aim of encompassing all functionalities of `airbase-ng`.
+ * 4. Enhance the output display to ensure optimal readability, especially for extensive outputs.
+ * 5. Unblock the loading screen during the up time of the Airbase ng and provide real time data update
+ */
+
+const title = "Create Fake Access Point with Airbase-ng";
+const description_userguide =
+    "Airbase-ng is a tool to create fake access points.\n\n" +
+    "Step 1: Type in the name of your fake host.\n" +
+    "Step 2: Select your desired channel.\n" +
+    "Step 3: Specify the WLAN interface to be used.\n" +
+    "Step 4: Click 'Start AP' to begin the process.\n" +
+    "Step 5: View the Output block below to see the results.\n\n";
+
+interface FormValuesType {
+    FakeHost: string;
+    Channel: string;
+    Wlan: string;
+}
+
+const AirbaseNG = () => {
+    const [loading, setLoading] = useState(false);
+    const [output, setOutput] = useState("");
+    const [pid, setPid] = useState("");
+
+    const form = useForm({
+        initialValues: {
+            FakeHost: "",
+            Channel: "",
+            Wlan: "",
+        },
+    });
+    /**
+     * handleProcessData: Callback to handle and append new data from the child process to the output.
+     * It updates the state by appending the new data received to the existing output.
+     * @param {string} data - The data received from the child process.
+     */
+    const handleProcessData = useCallback((data: string) => {
+        setOutput((prevOutput) => prevOutput + "\n" + data); // Append new data to the previous output.
+    }, []);
+
+    /**
+     * handleProcessTermination: Callback to handle the termination of the child process.
+     * Once the process termination is handled, it clears the process PID reference and
+     * deactivates the loading overlay.
+     * @param {object} param0 - An object containing information about the process termination.
+     * @param {number} param0.code - The exit code of the terminated process.
+     * @param {number} param0.signal - The signal code indicating how the process was terminated.
+     */
+    const handleProcessTermination = useCallback(
+        ({ code, signal }: { code: number; signal: number }) => {
+            if (code === 0) {
+                handleProcessData("\nProcess completed successfully.");
+            } else if (signal === 15) {
+                handleProcessData("\nProcess was manually terminated.");
+            } else {
+                handleProcessData(`\nProcess terminated with exit code: ${code} and signal code: ${signal}`);
+            }
+            // Clear the child process pid reference
+            setPid("");
+            // Cancel the Loading Overlay
+            setLoading(false);
+        },
+        [handleProcessData] // Dependency on the handleProcessData callback
+    );
+
+    /**
+     * onSubmit: Asynchronous handler for the form submission event.
+     * It sets up and triggers the airbase-ng tool with the given parameters.
+     * Once the command is executed, the results or errors are displayed in the output.
+     *
+     * @param {FormValuesType} values - The form values, containing the fake host name, channel, and WLAN interface.
+     */
+    const onSubmit = async (values: FormValuesType) => {
+        // Activate loading state to indicate ongoing process
+        setLoading(true);
+
+        // Construct arguments for the aircrack-ng command based on form input
+        const args = ["-e", values.FakeHost, "-c", values.Channel, values.Wlan];
+
+        // Execute the aircrack-ng command via helper method and handle its output or potential errors
+        CommandHelper.runCommandWithPkexec("airbase-ng", args, handleProcessData, handleProcessTermination)
+            .then(({ output, pid }) => {
+                // Update the UI with the results from the executed command
+                setOutput(output);
+                console.log(pid);
+                setPid(pid);
+            })
+            .catch((error) => {
+                // Display any errors encountered during command execution
+                setOutput(error.message);
+                // Deactivate loading state
+                setLoading(false);
+            });
+    };
+
+    /**
+     * clearOutput: Callback function to clear the console output.
+     * It resets the state variable holding the output, thereby clearing the display.
+     */
+    const clearOutput = useCallback(() => {
+        setOutput("");
+    }, [setOutput]);
+    return (
+        <form onSubmit={form.onSubmit(onSubmit)}>
+            {LoadingOverlayAndCancelButton(loading, pid)}
+            <Stack>
+                {UserGuide(title, description_userguide)}
+                <TextInput label={"Name of your fake Host"} required {...form.getInputProps("FakeHost")} />
+                <TextInput label={"Channel of choice"} required {...form.getInputProps("Channel")} />
+                <TextInput label={"Your Wlan"} required {...form.getInputProps("Wlan")} />
+                {SaveOutputToTextFile(output)}
+                <Button type={"submit"}>Start AP</Button>
+                <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
+            </Stack>
+        </form>
+    );
+};
+
+export default AirbaseNG;

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -52,6 +52,7 @@ import Busqueda from "./WalkthroughPages/Busqueda";
 import TheHarvester from "./theharvester/theharvester";
 import PayloadGenerator from "./msfvenom/msfvenom";
 import AircrackNG from "./AircrackNG/AircrackNG";
+import AirbaseNG from "./AirbaseNG/AirbaseNG";
 import Fcrackzip from "./Fcrackzip/Fcrackzip";
 import GoBusterTool from "./GobusterTool/Gobuster";
 import Keeper from "./WalkthroughPages/Keeper";
@@ -242,6 +243,13 @@ export const ROUTES: RouteProperties[] = [
         category: "",
     },
     //TOOLS BELOW THIS COMMENT - PLEASE ADDE NEW TOOLS IN ALPHABETICAL ORDER
+    {
+        name: "Airbase NG",
+        path: "/tools/AirbaseNG",
+        element: <AirbaseNG />,
+        description: "Airbase-ng is a tool to create fake access points",
+        category: "Wireless Attacks and Rouge Access Point Creation",
+    },
     {
         name: "Aircrack NG",
         path: "/tools/AircrackNG",

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -248,7 +248,7 @@ export const ROUTES: RouteProperties[] = [
         path: "/tools/AirbaseNG",
         element: <AirbaseNG />,
         description: "Airbase-ng is a tool to create fake access points",
-        category: "Wireless Attacks and Rouge Access Point Creation",
+        category: "Wireless Attacks and Rogue Access Point Creation",
     },
     {
         name: "Aircrack NG",

--- a/src/utils/CommandHelper.ts
+++ b/src/utils/CommandHelper.ts
@@ -23,6 +23,7 @@ export const CommandHelper = {
         const handle = await command.spawn();
         return handle;
     },
+
     /**
      * Helper method to run the given command and return the stdout/stderr result.
      * This replaces runCommand() and allows for a process to be manually terminated by the user
@@ -70,6 +71,96 @@ export const CommandHelper = {
             });
             if (pid !== undefined) {
                 resolve({ pid: pid, output: `$ ${commandString} ${args.join(" ")}\n\n${stdout}\n${stderr}` });
+            } else {
+                reject(new Error("Failed to get process PID."));
+            }
+        });
+    },
+    /**
+     * Implementation note, known bug, and limitations:
+     *
+     * Purpose:
+     * This function was introduced to facilitate developers in testing their code that requires elevated privileges. Prior to this,
+     * it was not possible to test code segments that demanded 'sudo'. With the incorporation of 'pkexec', we can now invoke commands
+     * with elevated privileges, thereby enabling more comprehensive testing.
+     *
+     * Current Bug:
+     * One of the limitations of this current implementation is that it doesn't keep track of the Child PID once the command starts.
+     * This essentially means that, as of now, there's no way to cancel or interrupt the command once it has been initiated.
+     * We are aware of this limitation and there are plans to address this in the future. However, for the time being, the bug persists.
+     *
+     * Implementation Limitation:
+     * When using this function, every command executed in the current component (e.g., functions like nmap or airbase-ng) will be run
+     * with root privileges. This means users will be prompted for the password every single time, leading to a potential user-experience
+     * inconvenience. Developers and users should be aware of this behavior and use the function judiciously.
+     *
+     * Scope Bug:
+     * There is an observed behavior wherein if you don't use `pkexec`, the `scope` is essential for specific commands (e.g., `snmp-check`)
+     * in order for the command to execute. However, when `pkexec` is employed, the scope seems to default to `pkexec`, making other scopes
+     * (like `snmp-check`) redundant or not required. This is an important nuance to be aware of when relying on the `scope` behavior.
+     *
+     * Usage:
+     * If you're looking to test commands requiring elevated privileges, simply replace the `runCommandGetPidAndOutput()` with this
+     * `runCommandWithPkexec()` function. When the command is executed correctly, a GUI will pop up prompting for the password of your
+     * machine. Ensure that you, or the user executing the command, know the password beforehand, as this is a security measure to gain
+     * elevated privileges.
+     *
+     * Note: It's essential to be cautious when testing with elevated privileges, especially in production or critical environments.
+     */
+
+    /**
+     * Execute a command with elevated privileges using 'pkexec'.
+     * This function mimics the behavior of `runCommandGetPidAndOutput()` but escalates privileges.
+     * 'pkexec' provides a GUI for user password input, making it a more user-friendly method for privilege escalation.
+     * This is especially useful for commands that traditionally need 'sudo'.
+     *
+     * @param commandString The primary command string to be executed.
+     * @param args Array of arguments to pass to the command.
+     * @param onData Callback function invoked upon receiving data from the command's output.
+     * @param onTermination Callback function invoked when the command process terminates.
+     * @returns A promise resolving to an object containing the PID and combined output of the command, or rejecting with an error message.
+     */
+
+    async runCommandWithPkexec(
+        commandString: string,
+        args: string[],
+        onData: (data: string) => void,
+        onTermination: ({ code, signal }: { code: number; signal: number }) => void
+    ): Promise<{ pid: string; output: string }> {
+        // Modify how the command is prepared with 'pkexec'
+        const command = new Command("pkexec", [commandString, ...args]);
+        const handle: Child = await command.spawn();
+        const pid = handle.pid.toString();
+        console.log(pid);
+
+        let stdout = "";
+        let stderr = "";
+
+        if (command.stdout) {
+            command.stdout.on("data", (data) => {
+                stdout += data.toString() + "\n";
+                onData(data.toString());
+            });
+        }
+
+        if (command.stderr) {
+            command.stderr.on("data", (data) => {
+                stderr += data.toString() + "\n";
+                onData(data.toString());
+            });
+        }
+
+        return new Promise<{ pid: string; output: string }>((resolve, reject) => {
+            command.on("close", ({ code, signal }: { code: number; signal: number }) => {
+                if (pid !== undefined) {
+                    onTermination({ code, signal });
+                    resolve({ pid: pid, output: `${stdout}\n${stderr}` });
+                } else {
+                    reject(new Error("Failed to get process PID."));
+                }
+            });
+            if (pid !== undefined) {
+                resolve({ pid: pid, output: `$ pkexec ${commandString} ${args.join(" ")}\n\n${stdout}\n${stderr}` });
             } else {
                 reject(new Error("Failed to get process PID."));
             }


### PR DESCRIPTION


**Pull Request Description:**

### New Functionality Introduced:

- **`runCommandWithPkexec()` Function**: 
  - This function facilitates developers in testing code that requires elevated privileges.
  - Replaces the need for `runCommandGetPidAndOutput()` when testing commands that need `sudo`.
  - Uses `pkexec` to provide a GUI for password input, enhancing the user experience.
  
- **`airbase-ng` Implementation**: 
  - Integrated support for the `airbase-ng` tool within the application.
  - Can now be tested using the new `runCommandWithPkexec()` function for elevated privileges.

### Known Bugs and Limitations:

- **Child PID Tracking Bug**: 
  - The function doesn't track the Child PID post-command initiation.
  - Commands cannot be cancelled or interrupted once initiated.
  - Plans are in place to address this in future updates.

- **Elevated Privilege Limitation**: 
  - Commands executed in the current component (e.g., `nmap` or `airbase-ng`) will run with root privileges.
  - Users are prompted for their machine password each time.
  - It's crucial to understand this behavior and use the function judiciously.

- **Scope Bug**:
  - Without `pkexec`, certain commands (e.g., `snmp-check`) require a specific `scope` to execute.
  - With `pkexec`, the `scope` defaults to `pkexec`, rendering other scopes redundant.
  - Users and developers should be cautious of this behavior when considering `scope` specifications.

### Usage Guidance:

- For testing commands that need elevated privileges, replace `runCommandGetPidAndOutput()` with `runCommandWithPkexec()`.
- On correct execution, a GUI will pop up prompting for the machine's password. Ensure the password is known beforehand.

### Note:
Proceed with caution when testing commands that require elevated privileges, especially in crucial environments.

