### PR TITLE
Fix issues with DNSMap tool as per the PTGUI Final Report

### DIFF
--- a/src/components/DNSMap/DNSMap.tsx
+++ b/src/components/DNSMap/DNSMap.tsx
@@ -10,15 +10,15 @@ import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/Overlay
 const title = "DNS Mapping for Subdomains (DNSMap)";
 const description_userguide =
     "DNSMap scans a domain for common subdomains using a built-in or an external wordlist (if specified using -w option). " +
-    "The internal wordlist has around 1000 words in English and Spanish as ns1, firewall servicios and smtp. " +
+    "The internal wordlist has around 1000 words in English and Spanish as ns1, firewall services and smtp. " +
     "So it will be possible search for smtp.example.com inside example.com automatically.\n\nInformation on the tool " +
     "can be found at: https://www.kali.org/tools/dnsmap/\n\n" +
     "Step 1: Enter a valid domain to be mapped.\n" +
     "       Eg: google.com\n\n" +
     "Step 2: Enter a delay between requests. Default is 10 (milliseconds). Can be left blank.\n" +
     "       Eg: 10\n\n" +
-    "Step 3: Click Start Mapping to commence the DNSMap tools operation.\n\n" +
-    "Step 4: View the Output block below to view the results of the tools execution.\n\n" +
+    "Step 3: Click 'Start Mapping' to commence the DNSMap tool's operation.\n\n" +
+    "Step 4: View the Output block below to view the results of the tool's execution.\n\n" +
     "Switch to Advanced Mode for further options.";
 
 interface FormValuesType {
@@ -110,15 +110,15 @@ const DNSMap = () => {
         const args = [`${values.domain}`, "-d", `${values.delay}`];
 
         if (values.wordlistPath) {
-            args.push(`-S ${values.wordlistPath}`);
+            args.push(`-w ${values.wordlistPath}`);
         }
 
         if (values.csvResultsFile) {
-            args.push(`-s ${values.csvResultsFile}`);
+            args.push(`-c ${values.csvResultsFile}`);
         }
 
         if (values.ipsToIgnore) {
-            args.push(`-t ${values.ipsToIgnore}`);
+            args.push(`-i ${values.ipsToIgnore}`);
         }
         const filteredArgs = args.filter((arg) => arg !== "");
         CommandHelper.runCommandGetPidAndOutput("dnsmap", filteredArgs, handleProcessData, handleProcessTermination)

--- a/src/components/DNSMap/DNSMap.tsx
+++ b/src/components/DNSMap/DNSMap.tsx
@@ -6,6 +6,7 @@ import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
 import { UserGuide } from "../UserGuide/UserGuide";
 import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile";
 import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
+import { l } from "vitest/dist/index-60e2a8e1";
 
 const title = "DNS Mapping for Subdomains (DNSMap)";
 const description_userguide =
@@ -107,19 +108,14 @@ const DNSMap = () => {
         setAllowSave(false);
 
         setLoading(true);
-        const args = [`${values.domain}`, "-d", `${values.delay}`];
+        const args = [values.domain, "-d", `${values.delay}`];
 
-        if (values.wordlistPath) {
-            args.push(`-w`, `${values.wordlistPath}`);
-        }
+        values.wordlistPath ? args.push(`-w`, values.wordlistPath) : undefined;
 
-        if (values.csvResultsFile) {
-            args.push(`-c`, `${values.csvResultsFile}`);
-        }
+        values.csvResultsFile ? args.push(`-c`, values.csvResultsFile) : undefined;
 
-        if (values.ipsToIgnore) {
-            args.push(`-i`, `${values.ipsToIgnore}`);
-        }
+        values.ipsToIgnore ? args.push(`-i`, values.ipsToIgnore) : undefined;
+
         const filteredArgs = args.filter((arg) => arg !== "");
         CommandHelper.runCommandGetPidAndOutput("dnsmap", filteredArgs, handleProcessData, handleProcessTermination)
             .then(({ pid, output }) => {

--- a/src/components/DNSMap/DNSMap.tsx
+++ b/src/components/DNSMap/DNSMap.tsx
@@ -110,15 +110,15 @@ const DNSMap = () => {
         const args = [`${values.domain}`, "-d", `${values.delay}`];
 
         if (values.wordlistPath) {
-            args.push(`-w ${values.wordlistPath}`);
+            args.push(`-w`, `${values.wordlistPath}`);
         }
 
         if (values.csvResultsFile) {
-            args.push(`-c ${values.csvResultsFile}`);
+            args.push(`-c`, `${values.csvResultsFile}`);
         }
 
         if (values.ipsToIgnore) {
-            args.push(`-i ${values.ipsToIgnore}`);
+            args.push(`-i`, `${values.ipsToIgnore}`);
         }
         const filteredArgs = args.filter((arg) => arg !== "");
         CommandHelper.runCommandGetPidAndOutput("dnsmap", filteredArgs, handleProcessData, handleProcessTermination)

--- a/src/components/DNSMap/DNSMap.tsx
+++ b/src/components/DNSMap/DNSMap.tsx
@@ -12,7 +12,7 @@ const title = "DNS Mapping for Subdomains (DNSMap)";
 const description_userguide =
     "DNSMap scans a domain for common subdomains using a built-in or an external wordlist (if specified using -w option). " +
     "The internal wordlist has around 1000 words in English and Spanish as ns1, firewall services and smtp. " +
-    "So it will be possible search for smtp.example.com inside example.com automatically.\n\nInformation on the tool " +
+    "So it will be possible to search for smtp.example.com inside example.com automatically.\n\nInformation on the tool " +
     "can be found at: https://www.kali.org/tools/dnsmap/\n\n" +
     "Step 1: Enter a valid domain to be mapped.\n" +
     "       Eg: google.com\n\n" +


### PR DESCRIPTION
Fixed the following:

1. Spelling errors in the tooltip text
2. When selecting an external wordlist, the DDT GUI uses the incorrect command -S instead of -w.
3. When selecting results output to a CSV file, the DDT GUI uses the incorrect command -s instead of -c.
4. When selecting an IP address to ignore, the DDT GUI uses the incorrect command -t instead of -i.