### PR TITLE
 fix: updated readme install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `.deb` that Tauri builds will automatically do this for us for actual toolki
 1. (New Method) Run the following command.
 
     ```
-    $ curl -sSL https://github.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/blob/main/install-update-media/install-ddt.py -o install-ddt.py && python3 install-ddt.py
+    $ curl -sSL https://raw.githubusercontent.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/blob/main/install-update-media/install-ddt.py -o install-ddt.py && python3 install-ddt.py
     ```
 
 2. (Old Method - Use in case of errors). Update your Kali.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `.deb` that Tauri builds will automatically do this for us for actual toolki
 1. (New Method) Run the following command.
 
     ```
-    $ curl -sSL https://raw.githubusercontent.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/blob/main/install-update-media/install-ddt.py -o install-ddt.py && python3 install-ddt.py
+    $ curl -sSL https://raw.githubusercontent.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/main/install-update-media/install-ddt.py -o install-ddt.py && python3 install-ddt.py
     ```
 
 2. (Old Method - Use in case of errors). Update your Kali.


### PR DESCRIPTION
Issue:
Issue detailed in  [https://github.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/issues/456] automated install not working correctly
Resolution:
In the commit [052773bcce2bc98a867a9adbbe27dfb38cb08d83]
 
Fixed the install command to reflect change from the plain git link, to the raw git link. 
 
Changes Made:
 
Changed install link. 

Testing:
Awaiting testing from testing team.