### PR TITLE
482 bug readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ The `.deb` that Tauri builds will automatically do this for us for actual toolki
 
 To install Deakin Detonator Toolkit on Kali, you can follow either the new or old methods. The new method is a one-step process that utilises a Python script. If that doesn't work, the old method will take you through the steps manually. 
 
+## New method
+
 1. (New Method) Run the following command.
 
     ```
     curl -sSL https://raw.githubusercontent.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/main/install-update-media/install-ddt.py -o install-ddt.py && python3 install-ddt.py
     ```
+## Old method
 
 2. (Old Method - Use in case of errors). Update your Kali.
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
 
 # 📷 Screenshot
 
+Once you have successfully implemented either method one or two, the application should open and look like the following screenshot: 
+
 <img src="https://github.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/blob/main/static/ddt_homepage.png" width="1000px">
 
 # 📷 Release

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The `.deb` that Tauri builds will automatically do this for us for actual toolki
 
 # 🔧 Setup
 
+To install Deakin Detonator Toolkit on Kali, you can follow either the new or old methods. The new method is a one-step process that utilises a Python script. If that doesn't work, the old method will take you through the steps manually. 
+
 1. (New Method) Run the following command.
 
     ```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
     ```
 
-7. Install Volta or Node. Volta now no longer support Apple silicon chip series (M series). Therefore we can use alternative like Node instead:
+7. Install Volta or Node. Volta now no longer support Apple silicon chip series (M series). Therefore we can use an alternative like Node instead:
 
     ### for Apple silicon series user
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The `.deb` that Tauri builds will automatically do this for us for actual toolki
 
 # 🔧 Setup
 
-To install Deakin Detonator Toolkit on Kali, you can follow either the new or old methods. The new method is a one-step process that utilises a Python script. If that doesn't work, the old method will take you through the steps manually. 
+To install Deakin Detonator Toolkit on Kali, you can follow either the new or old methods. The new method is a one&#8209;step process that utilises a Python script. If that doesn't work, the old method will take you through the steps manually. 
 
 ## New method
 

--- a/README.md
+++ b/README.md
@@ -28,25 +28,25 @@ The `.deb` that Tauri builds will automatically do this for us for actual toolki
 1. (New Method) Run the following command.
 
     ```
-    $ curl -sSL https://raw.githubusercontent.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/main/install-update-media/install-ddt.py -o install-ddt.py && python3 install-ddt.py
+    curl -sSL https://raw.githubusercontent.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/main/install-update-media/install-ddt.py -o install-ddt.py && python3 install-ddt.py
     ```
 
 2. (Old Method - Use in case of errors). Update your Kali.
 
     ```bash
-    $ sudo apt update
+    sudo apt update
     ```
 
 3. Upgrade your Kali.
 
     ```bash
-    $ sudo apt upgrade --fix-missing -y
+    sudo apt upgrade --fix-missing -y
     ```
 
 4. Install missing dependencies.
 
     ```bash
-    $ sudo apt install libwebkit2gtk-4.0-dev \
+    sudo apt install libwebkit2gtk-4.0-dev \
         build-essential \
         curl \
         wget \
@@ -69,7 +69,7 @@ The `.deb` that Tauri builds will automatically do this for us for actual toolki
 6. Install rust.
 
     ```bash
-    $ curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
+    curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
     ```
 
 7. Install volta or node. Volta now no longer support Apple silicon chip series (M series) therefore we can use alternative like node instead
@@ -77,13 +77,13 @@ The `.deb` that Tauri builds will automatically do this for us for actual toolki
     ### for Apple silicon series user
 
     ```bash
-    $ sudo apt install nodejs npm
+    sudo apt install nodejs npm
     ```
 
     ### for window machine with Intel/AMD
 
     ```bash
-    $ curl https://get.volta.sh | bash
+    curl https://get.volta.sh | bash
     ```
 
 8. Close your current terminal and open a new one.
@@ -93,13 +93,13 @@ The `.deb` that Tauri builds will automatically do this for us for actual toolki
     ### for Apple silicon series user
 
     ```bash
-    $ npm install node
+    npm install node
     ```
 
     ### for window machine with Intel/AMD
 
     ```bash
-    $ volta install node
+    volta install node
     ```
 
 10. Install yarn.
@@ -107,31 +107,31 @@ The `.deb` that Tauri builds will automatically do this for us for actual toolki
     ### for Apple silicon series user
 
     ```bash
-    $ npm install yarn
+    npm install yarn
     ```
 
     ### for window machine with Intel/AMD
 
     ```bash
-    $ volta install yarn
+    volta install yarn
     ```
 
 11. Clone the repo.
 
     ```bash
-    $ git clone https://github.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit
+    git clone https://github.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit
     ```
 
 12. Change current directory to the toolkit.
 
     ```bash
-    $ cd Deakin-Detonator-Toolkit
+    cd Deakin-Detonator-Toolkit
     ```
 
 13. Install project dependencies.
 
     ```bash
-    $ yarn install
+    yarn install
     ```
 
 14. Run the application (dev mode).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo houses the new version of the Deakin Detonator Toolkit application bui
 
 ## What is the Deakin Detonator Toolkit? 
 
-In its simplest definition, Deakin Detonator Toolkit is a penetration testing toolkit. The toolkit allows you to use a variety of tools, without needing the "know-how" of each command.
+In its simplest definition, the Deakin Detonator Toolkit is a penetration testing toolkit. The toolkit allows you to use a variety of tools, without needing the "know-how" of each command.
 
 # 🛠️ Exploit Development
 
@@ -29,7 +29,7 @@ The `.deb` that Tauri builds will automatically do this for us for actual toolki
 
 # 🔧 Setup
 
-To install Deakin Detonator Toolkit on Kali, you can follow either the new or old methods. The new method is a one&#8209;step process that utilises a Python script. If that doesn't work, the old method will take you through the steps manually. 
+To install the Deakin Detonator Toolkit on Kali, you can follow either the new or old methods. The new method is a one&#8209;step process that utilises a Python script. If that doesn't work, the old method will take you through the steps manually. 
 
 ## New method
 
@@ -81,7 +81,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
     ```
 
-7. Install Volta or Node. Volta now no longer support Apple silicon chip series (M series). Therefore we can use an alternative like Node instead:
+7. Install Volta or Node. Volta no longer supports Apple silicon chip series (M series). Therefore, we can use an alternative like Node instead:
 
     ### for Apple silicon series user
 
@@ -89,7 +89,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     sudo apt install nodejs npm
     ```
 
-    ### for Windows machine with Intel/AMD
+    ### for Windows machines with an Intel/AMD chipset
 
     ```bash
     curl https://get.volta.sh | bash
@@ -105,7 +105,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     npm install node
     ```
 
-    ### for Windows machine with Intel/AMD
+    ### for Windows machines with an Intel/AMD chipset
 
     ```bash
     volta install node
@@ -119,7 +119,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     npm install yarn
     ```
 
-    ### for Windows machine with Intel/AMD
+    ### for Windows machines with an Intel/AMD chipset
 
     ```bash
     volta install yarn

--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
 
 5. Close your current terminal and open a new one.
 
-6. Install rust:
+6. Install Rust:
 
     ```bash
     curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
     ```
 
-7. Install volta or node. Volta now no longer support Apple silicon chip series (M series) therefore we can use alternative like node instead:
+7. Install Volta or Node. Volta now no longer support Apple silicon chip series (M series). Therefore we can use alternative like Node instead:
 
     ### for Apple silicon series user
 
@@ -85,7 +85,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     sudo apt install nodejs npm
     ```
 
-    ### for window machine with Intel/AMD
+    ### for Windows machine with Intel/AMD
 
     ```bash
     curl https://get.volta.sh | bash
@@ -93,7 +93,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
 
 8. Close your current terminal and open a new one.
 
-9. Install node:
+9. Install Node:
 
     ### for Apple silicon series user
 
@@ -101,13 +101,13 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     npm install node
     ```
 
-    ### for window machine with Intel/AMD
+    ### for Windows machine with Intel/AMD
 
     ```bash
     volta install node
     ```
 
-10. Install yarn:
+10. Install Yarn:
 
     ### for Apple silicon series user
 
@@ -115,7 +115,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     npm install yarn
     ```
 
-    ### for window machine with Intel/AMD
+    ### for Windows machine with Intel/AMD
 
     ```bash
     volta install yarn

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
 
 ## New method
 
-1. Run the following command.
+1. Run the following command:
 
     ```
     curl -sSL https://raw.githubusercontent.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/main/install-update-media/install-ddt.py -o install-ddt.py && python3 install-ddt.py
@@ -42,13 +42,13 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     sudo apt update
     ```
 
-3. Upgrade your Kali.
+3. Upgrade your Kali:
 
     ```bash
     sudo apt upgrade --fix-missing -y
     ```
 
-4. Install missing dependencies.
+4. Install missing dependencies:
 
     ```bash
     sudo apt install libwebkit2gtk-4.0-dev \
@@ -71,13 +71,13 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
 
 5. Close your current terminal and open a new one.
 
-6. Install rust.
+6. Install rust:
 
     ```bash
     curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
     ```
 
-7. Install volta or node. Volta now no longer support Apple silicon chip series (M series) therefore we can use alternative like node instead
+7. Install volta or node. Volta now no longer support Apple silicon chip series (M series) therefore we can use alternative like node instead:
 
     ### for Apple silicon series user
 
@@ -93,7 +93,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
 
 8. Close your current terminal and open a new one.
 
-9. Install node.
+9. Install node:
 
     ### for Apple silicon series user
 
@@ -107,7 +107,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     volta install node
     ```
 
-10. Install yarn.
+10. Install yarn:
 
     ### for Apple silicon series user
 
@@ -121,25 +121,25 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     volta install yarn
     ```
 
-11. Clone the repo.
+11. Clone the repo:
 
     ```bash
     git clone https://github.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit
     ```
 
-12. Change current directory to the toolkit.
+12. Change current directory to the toolkit:
 
     ```bash
     cd Deakin-Detonator-Toolkit
     ```
 
-13. Install project dependencies.
+13. Install project dependencies:
 
     ```bash
     yarn install
     ```
 
-14. Run the application (dev mode).
+14. Run the application (dev mode):
 
     ```bash
     $ yarn run tauri dev

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
 
 ## New method
 
-1. (New Method) Run the following command.
+1. Run the following command.
 
     ```
     curl -sSL https://raw.githubusercontent.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/main/install-update-media/install-ddt.py -o install-ddt.py && python3 install-ddt.py

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To install Deakin Detonator Toolkit on Kali, you can follow either the new or ol
     ```
 ## Old method
 
-2. (Old Method - Use in case of errors). Update your Kali.
+1. Use this method if you get errors with the new method. Update your Kali:
 
     ```bash
     sudo apt update

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This repo houses the new version of the Deakin Detonator Toolkit application bui
 `src/` contains the source code for the UI.
 `src-tauri` contains the source code and configuration for the Tauri application.
 
+## What is the Deakin Detonator Toolkit? 
+
+In its simplest definition, Deakin Detonator Toolkit is a penetration testing toolkit. The toolkit allows you to use a variety of tools, without needing the "know-how" of each command.
+
 # 🛠️ Exploit Development
 
 All exploit scripts are expected to live in `/usr/share/ddt/`, and they will be executed by the Tauri application. It is recommended that you use Python for exploit development.


### PR DESCRIPTION
### Description
This pull request addresses issue #482, focusing on making the readme file easier to understand. The changes also include amendments to capitalisation. 

### Changes made
Removed $ sign from commands to make them easier to copy and paste. 
Created different headings for installation methods one and two to make it clear that they are separate methods. 
Added colons at the end of sentences preceding commands. 
Capitalised names of programming languages and brands (e.g. Windows). 
Added explanatory paragraph under screenshot heading. 
Added paragraph "What is the Deakin Detonator Toolkit?' 

#### Testing
I made a copy of the branch on my local computer and successfully ran the application after installing Yarn. 

Thank you for your consideration. 

Kind regards

Michael Pigott
