### PR TITLE
Foremost Bug Fix

### DIFF
--- a/src/components/Foremost/Foremost.tsx
+++ b/src/components/Foremost/Foremost.tsx
@@ -118,7 +118,7 @@ const ForemostTool = () => {
                 args.push(`-a`);
             }
 
-            //Only write audit files 
+            //Only write audit files
             if (values.auditFileOnly) {
                 args.push(`-w`);
             }
@@ -199,6 +199,20 @@ const ForemostTool = () => {
                 {/* Advanced Options */}
                 {checkedAdvanced && (
                     <Stack spacing="lg">
+                        {!checkedVerbose && (
+                            <Switch
+                                label="Quiet Mode"
+                                checked={checkedQuiet}
+                                onChange={(e) => setCheckedQuiet(e.currentTarget.checked)}
+                            />
+                        )}
+                        {!checkedQuiet && (
+                            <Switch
+                                label="Verbose Mode"
+                                checked={checkedVerbose}
+                                onChange={(e) => setCheckedVerbose(e.currentTarget.checked)}
+                            />
+                        )}
                         {/* Configuration File */}
                         <TextInput
                             label={"Configuration File"}

--- a/src/components/Foremost/Foremost.tsx
+++ b/src/components/Foremost/Foremost.tsx
@@ -181,20 +181,6 @@ const ForemostTool = () => {
                     placeholder={"Specify types (comma-separated) e.g., jpg,doc. if blank will retrieve all."}
                     {...form.getInputProps("types")}
                 />
-                {!checkedVerbose && (
-                    <Switch
-                        label="Quiet Mode"
-                        checked={checkedQuiet}
-                        onChange={(e) => setCheckedQuiet(e.currentTarget.checked)}
-                    />
-                )}
-                {!checkedQuiet && (
-                    <Switch
-                        label="Verbose Mode"
-                        checked={checkedVerbose}
-                        onChange={(e) => setCheckedVerbose(e.currentTarget.checked)}
-                    />
-                )}
 
                 {/* Advanced Options */}
                 {checkedAdvanced && (

--- a/src/components/Foremost/Foremost.tsx
+++ b/src/components/Foremost/Foremost.tsx
@@ -33,7 +33,7 @@ const ForemostTool = () => {
     // State hooks for loading, output, and advanced mode switch
     const [loading, setLoading] = useState(false);
     const [output, setOutput] = useState("");
-    const [checkedVerbose, setCheckedverbose] = useState(false);
+    const [checkedVerbose, setCheckedVerbose] = useState(false);
     const [checkedQuiet, setCheckedQuiet] = useState(false);
     const [checkedAdvanced, setCheckedAdvanced] = useState(false);
     const [pid, setPid] = useState("");
@@ -91,31 +91,38 @@ const ForemostTool = () => {
             args.push(`-c`, `${values.config}`);
         }
 
+        //Run the command in quiet mode
         if (checkedQuiet) {
             args.push(`-Q`);
         }
 
+        //Run the command in verbose mode
         if (checkedVerbose) {
             args.push(`-v`);
         }
 
+        //specify file type
         if (values.types) {
             args.push(`-t`, `${values.types}`);
         }
 
+        //Advanced Mode
         if (checkedAdvanced) {
+            //Enable indirect block detection
             if (values.indirectBlockDetection) {
                 args.push(`-d`);
             }
 
+            //Write all headers option
             if (values.allHeaders) {
                 args.push(`-a`);
             }
 
+            //Only write audit files 
             if (values.auditFileOnly) {
                 args.push(`-w`);
             }
-
+            //Enable Quick Mode
             if (values.quickMode) {
                 args.push(`-q`);
             }
@@ -185,7 +192,7 @@ const ForemostTool = () => {
                     <Switch
                         label="Verbose Mode"
                         checked={checkedVerbose}
-                        onChange={(e) => setCheckedverbose(e.currentTarget.checked)}
+                        onChange={(e) => setCheckedVerbose(e.currentTarget.checked)}
                     />
                 )}
 

--- a/src/components/Foremost/Foremost.tsx
+++ b/src/components/Foremost/Foremost.tsx
@@ -91,16 +91,6 @@ const ForemostTool = () => {
             args.push(`-c`, `${values.config}`);
         }
 
-        //Run the command in quiet mode
-        if (checkedQuiet) {
-            args.push(`-Q`);
-        }
-
-        //Run the command in verbose mode
-        if (checkedVerbose) {
-            args.push(`-v`);
-        }
-
         //specify file type
         if (values.types) {
             args.push(`-t`, `${values.types}`);
@@ -108,6 +98,16 @@ const ForemostTool = () => {
 
         //Advanced Mode
         if (checkedAdvanced) {
+            //Run the command in quiet mode
+            if (checkedQuiet) {
+                args.push(`-Q`);
+            }
+
+            //Run the command in verbose mode
+            if (checkedVerbose) {
+                args.push(`-v`);
+            }
+
             //Enable indirect block detection
             if (values.indirectBlockDetection) {
                 args.push(`-d`);

--- a/src/components/Foremost/Foremost.tsx
+++ b/src/components/Foremost/Foremost.tsx
@@ -1,4 +1,4 @@
-import { Button, LoadingOverlay, Stack, TextInput, Title, Checkbox, Switch } from "@mantine/core";
+import { Button, LoadingOverlay, Stack, TextInput, Title, Checkbox, Switch, Slider } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useCallback, useState } from "react";
 import { CommandHelper } from "../../utils/CommandHelper";
@@ -33,6 +33,8 @@ const ForemostTool = () => {
     // State hooks for loading, output, and advanced mode switch
     const [loading, setLoading] = useState(false);
     const [output, setOutput] = useState("");
+    const [checkedVerbose, setCheckedverbose] = useState(false);
+    const [checkedQuiet, setCheckedQuiet] = useState(false);
     const [checkedAdvanced, setCheckedAdvanced] = useState(false);
     const [pid, setPid] = useState("");
 
@@ -89,11 +91,11 @@ const ForemostTool = () => {
             args.push(`-c`, `${values.config}`);
         }
 
-        if (values.quiet) {
+        if (checkedQuiet) {
             args.push(`-Q`);
         }
 
-        if (values.verbose) {
+        if (checkedVerbose) {
             args.push(`-v`);
         }
 
@@ -172,18 +174,20 @@ const ForemostTool = () => {
                     placeholder={"Specify types (comma-separated) e.g., jpg,doc. if blank will retrieve all."}
                     {...form.getInputProps("types")}
                 />
-                <Stack spacing="lg">
-                    {/* Quiet Mode */}
-                    <Checkbox
-                        label={"Quiet Mode - enables quiet mode. Suppress output messages."}
-                        {...form.getInputProps("quiet" as keyof FormValuesType)}
+                {!checkedVerbose && (
+                    <Switch
+                        label="Quiet Mode"
+                        checked={checkedQuiet}
+                        onChange={(e) => setCheckedQuiet(e.currentTarget.checked)}
                     />
-                    {/* Verbose Mode */}
-                    <Checkbox
-                        label={"Verbose Mode - enables verbose mode. Logs all messages to screen."}
-                        {...form.getInputProps("verbose" as keyof FormValuesType)}
+                )}
+                {!checkedQuiet && (
+                    <Switch
+                        label="Verbose Mode"
+                        checked={checkedVerbose}
+                        onChange={(e) => setCheckedverbose(e.currentTarget.checked)}
                     />
-                </Stack>
+                )}
 
                 {/* Advanced Options */}
                 {checkedAdvanced && (

--- a/src/components/Foremost/Foremost.tsx
+++ b/src/components/Foremost/Foremost.tsx
@@ -210,18 +210,17 @@ const ForemostTool = () => {
                         placeholder={"Specify types (comma-separated) e.g., jpg,doc. if blank will retrieve all."}
                         {...form.getInputProps("types")}
                     />
-                    <Stack spacing="lg">
-                    </Stack>
+                    <Stack spacing="lg"></Stack>
 
                     {/* Advanced Options */}
                     {checkedAdvanced && (
                         <Stack spacing="lg">
                             {!checkedVerbose && (
-                            <Switch
-                                label="Quiet Mode"
-                                checked={checkedQuiet}
-                                onChange={(e) => setCheckedQuiet(e.currentTarget.checked)}
-                            />
+                                <Switch
+                                    label="Quiet Mode"
+                                    checked={checkedQuiet}
+                                    onChange={(e) => setCheckedQuiet(e.currentTarget.checked)}
+                                />
                             )}
                             {!checkedQuiet && (
                                 <Switch


### PR DESCRIPTION
# Changes

- Verbose and Quiet mode: Fixed the bug so both can't be selected at once
- Write All Headers Error: Unable to reproduce the error. Tool uses the correct parameter -a for "write all headers"
- White Screen Error: Unable to reproduce the error. Clicking on quiet and verbose modes does not trigger white screen