### PR TITLE
505 feature request give the option of stability for arjun

### DIFF
--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -14,8 +14,9 @@ const description_userguide =
     "It is a multi-threaded application, can handle rate limits and supports GET,POST,XML and JSON methods. " +
     " \n\nKali's Arjun Information Page: https://www.kali.org/tools/arjun/ \n\nHow to use Arjun:\n\nStep 1: Enter a valid URL.\n" +
     "       E.g. https://www.deakin.edu.au\n\nStep 2: Enter an Optional Json Output filename.\n        E.g. arjunoutput " +
-    "\n\nStep 3: Click the scan option to commence scan. " +
-    "\n\nStep 4: View the Output block below to view the results of the tool's execution.";
+    "\n\nStep 3: Turn on the stability function if you want Arjun to prioritise stability over speed (can take a long time, so get a coffee if using this functionality)." +
+    "\n\nStep 4: Click the scan option to commence scan. " +
+    "\n\nStep 5: View the Output block below to view the results of the tool's execution.";
 
 interface FormValues {
     url: string;

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -87,7 +87,7 @@ export function Arjuntool() {
         const args = ["-u", values.url];
 
         // Conditional. If the user has specified stability, add the --stable option to the command.
-        if (values.stability == true) {
+        if (values.stability) {
             args.push("--stable");
         }
 

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -24,7 +24,7 @@ interface FormValues {
     stability: boolean;
 }
 
-export function Arjun() {
+export function Arjuntool() {
     const [loading, setLoading] = useState(false);
     const [output, setOutput] = useState("");
     const [pid, setPid] = useState("");
@@ -132,4 +132,4 @@ export function Arjun() {
     );
 }
 
-export default Arjun;
+export default Arjuntool;

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -24,7 +24,7 @@ interface FormValues {
     stability: boolean;
 }
 
-export function Arjuntool() {
+export function Arjun() {
     const [loading, setLoading] = useState(false);
     const [output, setOutput] = useState("");
     const [pid, setPid] = useState("");
@@ -132,4 +132,4 @@ export function Arjuntool() {
     );
 }
 
-export default Arjuntool;
+export default Arjun;

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -34,6 +34,7 @@ export function Arjuntool() {
         initialValues: {
             url: "",
             output_filename: "",
+            stability: false,
         },
     });
 

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -88,7 +88,7 @@ export function Arjuntool() {
 
         // Conditional. If the user has specified stability, add the --stable option to the command.
         if (values.stability == true) {
-            args.push("--stable")
+            args.push("--stable");
         }
 
         if (values.output_filename) {
@@ -119,11 +119,7 @@ export function Arjuntool() {
             <Stack>
                 {UserGuide(title, description_userguide)}
                 <TextInput label={"URL"} required {...form.getInputProps("url")} />
-                <Switch
-                            size="md"
-                            label="Stability mode"
-                            {...form.getInputProps("stability" as keyof FormValues)}
-                        />
+                <Switch size="md" label="Stability mode" {...form.getInputProps("stability" as keyof FormValues)} />
                 <Button type={"submit"}>Scan</Button>
                 {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
                 <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -1,4 +1,4 @@
-import { Button, LoadingOverlay, Stack, TextInput } from "@mantine/core";
+import { Button, LoadingOverlay, Stack, TextInput, Switch } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useCallback, useState } from "react";
 import { CommandHelper } from "../../utils/CommandHelper";
@@ -111,6 +111,11 @@ export function Arjuntool() {
             <Stack>
                 {UserGuide(title, description_userguide)}
                 <TextInput label={"URL"} required {...form.getInputProps("url")} />
+                <Switch
+                            size="md"
+                            label="Stability mode"
+                            /*{...form.getInputProps("reverseLookup" as keyof FormValuesType)}*/
+                        />
                 <Button type={"submit"}>Scan</Button>
                 {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
                 <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -20,6 +20,7 @@ const description_userguide =
 interface FormValues {
     url: string;
     output_filename: string;
+    stability: boolean;
 }
 
 export function Arjuntool() {

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -86,7 +86,7 @@ export function Arjuntool() {
         const args = ["-u", values.url];
 
         // Conditional. If the user has specified stability, add the --stable option to the command.
-        if (values.stability) {
+        if (values.stability == true) {
             args.push("--stable")
         }
 
@@ -121,7 +121,7 @@ export function Arjuntool() {
                 <Switch
                             size="md"
                             label="Stability mode"
-                            /*{...form.getInputProps("reverseLookup" as keyof FormValuesType)}*/
+                            {...form.getInputProps("stability" as keyof FormValues)}
                         />
                 <Button type={"submit"}>Scan</Button>
                 {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -16,7 +16,7 @@ const description_userguide =
     "       E.g. https://www.deakin.edu.au\n\nStep 2: Enter an optional JSON output filename.\n        E.g. arjunoutput " +
     "\n\nStep 3: Turn on the stability function if you want Arjun to prioritise stability over speed (can take a long time, so get a coffee if using this functionality)." +
     "\n\nStep 4: Click the scan option to commence scanning. " +
-    "\n\nStep 5: View the Output block below to view the results of the tool's execution.";
+    "\n\nStep 5: View the output block below to view the results of the tool's execution.";
 
 interface FormValues {
     url: string;

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -15,7 +15,7 @@ const description_userguide =
     " \n\nKali's Arjun Information Page: https://www.kali.org/tools/arjun/ \n\nHow to use Arjun:\n\nStep 1: Enter a valid URL.\n" +
     "       E.g. https://www.deakin.edu.au\n\nStep 2: Enter an Optional Json Output filename.\n        E.g. arjunoutput " +
     "\n\nStep 3: Turn on the stability function if you want Arjun to prioritise stability over speed (can take a long time, so get a coffee if using this functionality)." +
-    "\n\nStep 4: Click the scan option to commence scan. " +
+    "\n\nStep 4: Click the scan option to commence scanning. " +
     "\n\nStep 5: View the Output block below to view the results of the tool's execution.";
 
 interface FormValues {

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -85,6 +85,10 @@ export function Arjuntool() {
 
         const args = ["-u", values.url];
 
+        if (values.stability) {
+            args.push("--stable")
+        }
+
         if (values.output_filename) {
             args.push("-o", values.output_filename);
         }

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -10,7 +10,7 @@ import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFil
 const title = "Arjun";
 const description_userguide =
     "Arjun is a command-line tool specifically designed to look for hidden HTTP parameters. " +
-    "Arjun will try to discover parameters and give you new set of endpoints to test on. " +
+    "Arjun will try to discover parameters and give you a new set of endpoints to test on. " +
     "It is a multi-threaded application, can handle rate limits and supports GET,POST,XML and JSON methods. " +
     " \n\nKali's Arjun Information Page: https://www.kali.org/tools/arjun/ \n\nHow to use Arjun:\n\nStep 1: Enter a valid URL.\n" +
     "       E.g. https://www.deakin.edu.au\n\nStep 2: Enter an Optional Json Output filename.\n        E.g. arjunoutput " +

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -11,7 +11,7 @@ const title = "Arjun";
 const description_userguide =
     "Arjun is a command-line tool specifically designed to look for hidden HTTP parameters. " +
     "Arjun will try to discover parameters and give you a new set of endpoints to test on. " +
-    "It is a multi-threaded application, can handle rate limits and supports GET,POST,XML and JSON methods. " +
+    "It is a multi-threaded application that can handle rate limits and supports GET,POST,XML and JSON methods. " +
     " \n\nKali's Arjun Information Page: https://www.kali.org/tools/arjun/ \n\nHow to use Arjun:\n\nStep 1: Enter a valid URL.\n" +
     "       E.g. https://www.deakin.edu.au\n\nStep 2: Enter an Optional Json Output filename.\n        E.g. arjunoutput " +
     "\n\nStep 3: Turn on the stability function if you want Arjun to prioritise stability over speed (can take a long time, so get a coffee if using this functionality)." +

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -85,6 +85,7 @@ export function Arjuntool() {
 
         const args = ["-u", values.url];
 
+        // Conditional. If the user has specified stability, add the --stable option to the command.
         if (values.stability) {
             args.push("--stable")
         }

--- a/src/components/Arjuntool/Arjuntool.tsx
+++ b/src/components/Arjuntool/Arjuntool.tsx
@@ -13,7 +13,7 @@ const description_userguide =
     "Arjun will try to discover parameters and give you a new set of endpoints to test on. " +
     "It is a multi-threaded application that can handle rate limits and supports GET,POST,XML and JSON methods. " +
     " \n\nKali's Arjun Information Page: https://www.kali.org/tools/arjun/ \n\nHow to use Arjun:\n\nStep 1: Enter a valid URL.\n" +
-    "       E.g. https://www.deakin.edu.au\n\nStep 2: Enter an Optional Json Output filename.\n        E.g. arjunoutput " +
+    "       E.g. https://www.deakin.edu.au\n\nStep 2: Enter an optional JSON output filename.\n        E.g. arjunoutput " +
     "\n\nStep 3: Turn on the stability function if you want Arjun to prioritise stability over speed (can take a long time, so get a coffee if using this functionality)." +
     "\n\nStep 4: Click the scan option to commence scanning. " +
     "\n\nStep 5: View the Output block below to view the results of the tool's execution.";

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -46,7 +46,7 @@ import WPScan from "./WPScan/WPScan";
 import Eyewitness from "./eyewitness/eyewitness";
 import MrRobot from "./WalkthroughPages/MrRobot";
 import Parsero from "./parsero/parsero";
-import Arjun from "./Arjuntool/Arjuntool";
+import Arjuntool from "./Arjuntool/Arjuntool";
 import ForemostTool from "./Foremost/Foremost";
 import Busqueda from "./WalkthroughPages/Busqueda";
 import TheHarvester from "./theharvester/theharvester";
@@ -267,8 +267,8 @@ export const ROUTES: RouteProperties[] = [
     },
     {
         name: "Arjun",
-        path: "/tools/Arjun",
-        element: <Arjun />,
+        path: "/tools/Arjuntool",
+        element: <Arjuntool />,
         description: "Arjun can find query parameters for URL endpoints.",
         category: "Web Application Testing",
     },

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -46,7 +46,7 @@ import WPScan from "./WPScan/WPScan";
 import Eyewitness from "./eyewitness/eyewitness";
 import MrRobot from "./WalkthroughPages/MrRobot";
 import Parsero from "./parsero/parsero";
-import Arjuntool from "./Arjuntool/Arjuntool";
+import Arjun from "./Arjuntool/Arjuntool";
 import ForemostTool from "./Foremost/Foremost";
 import Busqueda from "./WalkthroughPages/Busqueda";
 import TheHarvester from "./theharvester/theharvester";
@@ -266,9 +266,9 @@ export const ROUTES: RouteProperties[] = [
         category: "Web Application Testing",
     },
     {
-        name: "Arjuntool",
-        path: "/tools/Arjuntool",
-        element: <Arjuntool />,
+        name: "Arjun",
+        path: "/tools/Arjun",
+        element: <Arjun />,
         description: "Arjun can find query parameters for URL endpoints.",
         category: "Web Application Testing",
     },


### PR DESCRIPTION
### Description

This pull request addresses issue #505, adding the stability switch to the Arjun tool. 

### Changes made 

* Imported the switch module into Arjuntool.tsx, so the tool can access the [switch feature](https://mantine.dev/core/switch/) from Mantine. 
* Added stability as a new boolean value of the FormValues object. 
* Set the initial value of the stability switch as false. 
* Added an if statement that pushes the option --stable to the args variable if the stability switch is turned on. 
* Added information to the tooltip that explains the stability option. 
* Updated the name of the tool from "Arjuntool" to "Arjun" in RouteWrapper.tsx. The tool is [called Arjun](https://www.kali.org/tools/arjun/) rather than Arjuntool. 
* Ran Prettier over Arjuntool.tsx to fix up style errors. 

### Testing

I ran the tool over Metasploitable's MyPhpAdmin and it ran successfully in both stability and non-stability modes. 

### Note

You will notice in the code that I originally changed the name of the Arjuntool component to Arjun, but I then changed it back. I changed my mind because I wanted the name of the component to match the name of the tsx file. 