### PR TITLE
758-bug-attack-vectors-landing-page-not-sorted-alphabetically

### DIFF
--- a/src/pages/AttackVectors.tsx
+++ b/src/pages/AttackVectors.tsx
@@ -3,7 +3,12 @@ import { getAttackVectors } from "../components/RouteWrapper";
 import ToolItem from "../components/ToolItem/ToolItem";
 
 export function AttackVectors() {
-    const rows = getAttackVectors().map((tool) => {
+    const attackVectors = getAttackVectors();
+
+    // Sort the attack vectors alphabetically by name
+    const sortedAttackVectors = attackVectors.sort((a, b) => a.name.localeCompare(b.name));
+
+    const rows = sortedAttackVectors.map((tool) => {
         return (
             <ToolItem
                 title={tool.name}
@@ -22,7 +27,7 @@ export function AttackVectors() {
                 <thead>
                     <tr>
                         <th>Attack Vector name</th>
-                        <th>Atack description</th>
+                        <th>Attack description</th>
                         <th>Controls</th>
                     </tr>
                 </thead>


### PR DESCRIPTION
I added a line to sort the attackVectors array using the JavaScript sort method, which compares the name properties of the objects.

The localeCompare method ensures the sorting is done in a locale-sensitive manner, which is generally a good practice when dealing with strings.

Mapping Sorted Vectors:

The sorted array is then mapped to ToolItem components as before.

This ensures that the attack vectors are displayed in alphabetical order on the landing page.