### PR TITLE
769: Fix NSLookup Tool output bug

### DIFF
--- a/src/components/NSLookupTool/NSLookupTool.tsx
+++ b/src/components/NSLookupTool/NSLookupTool.tsx
@@ -92,7 +92,7 @@ export function NSLookup() {
         setAllowSave(false);
 
         setLoading(true);
-        const args = ["-s", values.ipaddress];
+        const args = [values.ipaddress];
         CommandHelper.runCommandGetPidAndOutput("nslookup", args, handleProcessData, handleProcessTermination)
             .then(({ pid, output }) => {
                 setPid(pid);


### PR DESCRIPTION
The NSLookup tool's output screen showed a persistent bug where an incorrect '-s' was showing in the output screen. This bug produced incorrect output command execution. The '-s' was declared in the code with a constant. I fixed issue by changing the tool's execution logic's command structure such that the "-s" flag is no more inadvertently introduced. 

![Screensh](https://github.com/user-attachments/assets/a0c98a76-806c-47c9-a8e7-dea0a1410c2a)
