### PR TITLE
790 feature request masscan tool implementation

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -183,6 +183,11 @@
                         "args": true
                     },
                     {
+                        "name": "masscan",
+                        "cmd": "masscan",
+                        "args": true
+                    },
+                    {
                         "name": "metagoofil",
                         "cmd": "metagoofil",
                         "args": true

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -47,13 +47,13 @@ const Masscan = () => {
     const steps =
         "=== Required ===\n" +
         "Step 1: Input a single IP address or an IP address range/subnet to scan.\n" +
-        "Step 2: Input a port or range of ports to scan. Alternativley check the common ports box and input n number of common ports to scan.\n" +
+        "Step 2: Input a port or range of ports to scan. Alternatively check the common ports box and input n number of common ports to scan.\n" +
         " \n" +
         "=== Optional ===\n" +
         "Step 3: Input a wait time to allow Masscan to wait after the last packet is sent to receive any delayed responses.\n" +
         "Step 4: Input a packet rate to deterine how many packets are sent per second (Slower rates can help avoid detection).\n" +
         "Step 5: Input a single IP address or an IP address range to exclude from the scan.\n" +
-        "Step 6: Input a network interface to send and recieve packets from during the scan.\n" +
+        "Step 6: Input a network interface to send and receive packets from during the scan.\n" +
         "Step 7: Check the banner grabbing checkbox to attempt to identify services running on scanned ports.\n" +
         "Step 8: Check the verbose checkbox to run the command in verbose mode.\n";
     const sourceLink = ""; // Link to the source code

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -124,7 +124,7 @@ const Masscan = () => {
         }
 
         // Execute the Masscan command via helper method and handle its output or potential errors
-        CommandHelper.runCommandGetPidAndOutput(
+        CommandHelper.runCommandWithPkexec(
             "masscan",
             [...args, "--no-color"],
             handleProcessData,

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -162,7 +162,7 @@ const Masscan = () => {
         // Execute the Masscan command via helper method and handle its output or potential errors
         CommandHelper.runCommandWithPkexec(
             "masscan",
-            [...args, "--no-color"],
+            args,
             handleProcessData,
             handleProcessTermination
         )

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -15,6 +15,8 @@ import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 interface FormValuesType {
     targetIP: string;
     targetPort: string;
+    waitTime: string;
+    packetRate: string;
 }
 
 /**
@@ -49,6 +51,8 @@ const Masscan = () => {
         initialValues: {
             targetIP: "",
             targetPort: "",
+            waitTime: "",
+            packetRate: "",
         },
     });
 
@@ -117,7 +121,7 @@ const Masscan = () => {
 
         // Construct arguments for the Masscan command based on form input
         let args = [];
-        args = [values.targetIP, '-p', values.targetPort, ];
+        args = [values.targetIP, '-p', values.targetPort];
         
         if (verboseMode) {
             args.push("-v"); // Add verbose mode option if enabled
@@ -182,6 +186,8 @@ const Masscan = () => {
                     {LoadingOverlayAndCancelButton(loading, pid)}
                     <TextInput label="IP Address/Range/Subnet" required {...form.getInputProps("targetIP")} />
                     <TextInput label="Port/Port Range" required {...form.getInputProps("targetPort")} />
+                    <TextInput label="Response Wait Timer" {...form.getInputProps("waitTime")} />
+                    <TextInput label="Packet Send Rate" {...form.getInputProps("packetRate")} />
                     <Checkbox
                         label="Verbose Mode"
                         checked={verboseMode}

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -41,7 +41,8 @@ const Masscan = () => {
 
     // Component Constants
     const title = "Masscan";
-    const description = "Masscan is a network reconnaissance tool designed to scan large IP ranges for open ports and services faster than traditional scanners.";
+    const description =
+        "Masscan is a network reconnaissance tool designed to scan large IP ranges for open ports and services faster than traditional scanners.";
     const steps =
         "=== Required ===\n" +
         "Step 1: Input a single IP address or an IP address range/subnet to scan.\n" +
@@ -135,12 +136,12 @@ const Masscan = () => {
 
         // Construct arguments for the Masscan command based on form input
         let args = [];
-        args = [values.targetIP, '-p', values.targetPort];
+        args = [values.targetIP, "-p", values.targetPort];
 
         // Check if waitTime has a value and push it to args
         if (values.waitTime) {
             args.push("--wait", values.waitTime);
-        }  
+        }
 
         // Check if packetRate has a value and push it to args
         if (values.packetRate) {
@@ -161,18 +162,13 @@ const Masscan = () => {
         if (values.topPorts) {
             args.push("--interface", values.interface);
         }
-        
+
         if (verboseMode) {
             args.push("-v"); // Add verbose mode option if enabled
         }
 
         // Execute the Masscan command via helper method and handle its output or potential errors
-        CommandHelper.runCommandWithPkexec(
-            "masscan",
-            args,
-            handleProcessData,
-            handleProcessTermination
-        )
+        CommandHelper.runCommandWithPkexec("masscan", args, handleProcessData, handleProcessTermination)
             .then(() => {
                 // Deactivate loading state
                 setLoading(false);
@@ -183,7 +179,7 @@ const Masscan = () => {
                 // Deactivate loading state
                 setLoading(false);
             });
-            setAllowSave(true);
+        setAllowSave(true);
     };
 
     /**
@@ -228,16 +224,39 @@ const Masscan = () => {
                         checked={checkedTopPorts}
                         onChange={(e) => setCheckedTopPorts(e.currentTarget.checked)}
                     />
-                    <TextInput label="IP Address/Range/Subnet" required {...form.getInputProps("targetIP")} placeholder="e.g. 192.168.1.0" />
+                    <TextInput
+                        label="IP Address/Range/Subnet"
+                        required
+                        {...form.getInputProps("targetIP")}
+                        placeholder="e.g. 192.168.1.0"
+                    />
                     {checkedTopPorts ? (
-                        <TextInput label="Scan Common Ports" required {...form.getInputProps("topPorts")} placeholder="e.g. 100" />
-                    ):(
-                        <TextInput label="Port/Port Range" required {...form.getInputProps("targetPort")} placeholder="e.g. 80 or 80-100" />
+                        <TextInput
+                            label="Scan Common Ports"
+                            required
+                            {...form.getInputProps("topPorts")}
+                            placeholder="e.g. 100"
+                        />
+                    ) : (
+                        <TextInput
+                            label="Port/Port Range"
+                            required
+                            {...form.getInputProps("targetPort")}
+                            placeholder="e.g. 80 or 80-100"
+                        />
                     )}
                     <TextInput label="Response Wait Timer" {...form.getInputProps("waitTime")} placeholder="e.g. 5" />
                     <TextInput label="Packet Send Rate" {...form.getInputProps("packetRate")} placeholder="e.g. 1000" />
-                    <TextInput label="Exclude IP(s)" {...form.getInputProps("excludedIP")} placeholder="e.g. 192.168.1.4" />
-                    <TextInput label="Select Network Interface" {...form.getInputProps("interface")} placeholder="e.g. eth0" />
+                    <TextInput
+                        label="Exclude IP(s)"
+                        {...form.getInputProps("excludedIP")}
+                        placeholder="e.g. 192.168.1.4"
+                    />
+                    <TextInput
+                        label="Select Network Interface"
+                        {...form.getInputProps("interface")}
+                        placeholder="e.g. eth0"
+                    />
                     <Checkbox
                         label="Verbose Mode"
                         checked={verboseMode}

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -18,6 +18,7 @@ interface FormValuesType {
     waitTime: string;
     packetRate: string;
     excludedIP: string;
+    topPorts: string;
 }
 
 /**
@@ -55,6 +56,7 @@ const Masscan = () => {
             waitTime: "",
             packetRate: "",
             excludedIP: "",
+            topPorts: "",
         },
     });
 
@@ -139,6 +141,11 @@ const Masscan = () => {
         if (values.excludedIP) {
             args.push("--exclude", values.excludedIP); // Add verbose mode option if enabled
         }
+
+        // Check if excludedIP has a value and push it to args
+        if (values.topPorts) {
+            args.push("--top-ports", values.topPorts); // Add verbose mode option if enabled
+        }
         
         if (verboseMode) {
             args.push("-v"); // Add verbose mode option if enabled
@@ -206,6 +213,7 @@ const Masscan = () => {
                     <TextInput label="Response Wait Timer" {...form.getInputProps("waitTime")} />
                     <TextInput label="Packet Send Rate" {...form.getInputProps("packetRate")} />
                     <TextInput label="Exclude IP(s)" {...form.getInputProps("excludedIP")} />
+                    <TextInput label="Scan Common Ports" {...form.getInputProps("topPorts")} />
                     <Checkbox
                         label="Verbose Mode"
                         checked={verboseMode}

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -1,75 +1,147 @@
-import { Button, NativeSelect, Stack, TextInput } from "@mantine/core";
+import { useState, useEffect, useCallback } from "react";
+import { Button, Stack, TextInput, Checkbox } from "@mantine/core";
 import { useForm } from "@mantine/form";
-import { useState } from "react";
 import { CommandHelper } from "../../utils/CommandHelper";
 import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
 import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile";
 import { RenderComponent } from "../UserGuide/UserGuide";
+import InstallationModal from "../InstallationModal/InstallationModal";
+import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
+import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 
-// Component Constants.
-const title = "Masscan"; // Title of the component.
-const description = "Masscan is a tool used to..."; // Description of the component.
-const steps =
-    "Step 1: ...\n" +
-    "Step 2: ...";
-const sourceLink = ""; // Link to the source code (or Kali Tools).
-const tutorial = ""; // Link to the official documentation/tutorial.
-const dependencies = ["masscan"]; // Contains the dependencies required by the component.
-
-//Variables
-interface FormValuesType { //Relevant form values to be added as Masscan options are added
-    masscanOptions: string; 
+/**
+ * Represents the form values for the Masscan component.
+ */
+interface FormValuesType {
+    input1: string;
 }
 
-//Masscan Options
-const masscanOptions = [ //More options to be added (version check could be kept?)
-    "Version Check"
-];
-
+/**
+ * The Masscan component.
+ * @returns The Masscan component.
+ */
 const Masscan = () => {
-    var [output, setOutput] = useState("");
-    const [selectedMasscanOption, setSelectedMasscanOption] = useState("");
+    // Component state variables
+    const [loading, setLoading] = useState(false); // State variable to indicate loading state
+    const [output, setOutput] = useState(""); // State variable to store the output of the command execution
     const [allowSave, setAllowSave] = useState(false); // State variable to allow saving of output
     const [hasSaved, setHasSaved] = useState(false); // State variable to indicate if output has been saved
-    const [loading, setLoading] = useState(false); // State variable to indicate loading state
+    const [isCommandAvailable, setIsCommandAvailable] = useState(false); // State variable to check if the command is available.
+    const [opened, setOpened] = useState(!isCommandAvailable); // State variable that indicates if the modal is opened.
+    const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state of the modal.
+    const [pid, setPid] = useState(""); // State variable to store the process ID of the command execution.
+    const [verboseMode, setVerboseMode] = useState(false); // State variable for verbose mode
 
-    let form = useForm({ //Relevant form values to be added as Masscan options are added
+    // Component Constants
+    const title = "Masscan";
+    const description = "Masscan is a...";
+    const steps =
+        "Step 1: \n" +
+        "Step 2: \n" +
+        "Step 3: \n";
+    const sourceLink = ""; // Link to the source code
+    const tutorial = ""; // Link to the official documentation/tutorial
+    const dependencies = ["masscan"]; // Contains the dependencies required by the component.
+
+    // Form hook to handle form input
+    let form = useForm({
         initialValues: {
             input1: "",
         },
     });
 
+    useEffect(() => {
+        // Check if the command is available and set the state variables accordingly.
+        checkAllCommandsAvailability(dependencies)
+            .then((isAvailable) => {
+                setIsCommandAvailable(isAvailable); // Set the command availability state
+                setOpened(!isAvailable); // Set the modal state to opened if the command is not available
+                setLoadingModal(false); // Set loading to false after the check is done
+            })
+            .catch((error) => {
+                console.error("An error occurred:", error);
+                setLoadingModal(false); // Also set loading to false in case of error
+            });
+    }, []);
+
+    /**
+     * handleProcessData: Callback to handle and append new data from the child process to the output.
+     * It updates the state by appending the new data received to the existing output.
+     * @param {string} data - The data received from the child process.
+     */
+    const handleProcessData = useCallback((data: string) => {
+        setOutput((prevOutput) => prevOutput + "\n" + data); // Append new data to the previous output.
+    }, []);
+
+    /**
+     * handleProcessTermination: Callback to handle the termination of the child process.
+     * Once the process termination is handled, it clears the process PID reference and
+     * deactivates the loading overlay.
+     * @param {object} param - An object containing information about the process termination.
+     * @param {number} param.code - The exit code of the terminated process.
+     * @param {number} param.signal - The signal code indicating how the process was terminated.
+     */
+    const handleProcessTermination = useCallback(
+        ({ code, signal }: { code: number; signal: number }) => {
+            // If the process was successful, display a success message.
+            if (code === 0) {
+                handleProcessData("\nProcess completed successfully.");
+
+                // If the process was terminated manually, display a termination message.
+            } else if (signal === 15) {
+                handleProcessData("\nProcess was manually terminated.");
+
+                // If the process was terminated with an error, display the exit and signal codes.
+            } else {
+                handleProcessData(`\nProcess terminated with exit code: ${code} and signal code: ${signal}`);
+            }
+
+            // Clear the child process pid reference. There is no longer a valid process running.
+            setPid("");
+
+            // Cancel the loading overlay. The process has completed.
+            setLoading(false);
+        },
+        [handleProcessData] // Dependency on the handleProcessData callback
+    );
+
+    /**
+     * Handles form submission for the Masscan component.
+     * @param {FormValuesType} values - The form values containing the target domain.
+     */
     const onSubmit = async (values: FormValuesType) => {
-        // Set loading state to true and disallow output saving
+        // Activate loading state to indicate ongoing process
         setLoading(true);
-        setAllowSave(false);
 
-        let args = [``];
-
-        //Switch case
-        switch (values.masscanOptions) {
-            case "Version Check": //This version check option is a baseline to test that Masscan functions
-                args = [`--version`];
-
-                try {
-                    let output = await CommandHelper.runCommand("masscan", args);
-                    setOutput(output);
-                } catch (e: any) {
-                    setOutput(e);
-                } finally{
-                    // Set loading state to false and allow output saving
-                    setLoading(false);
-                    setAllowSave(true);
-                }
-
-                break;
+        // Construct arguments for the Masscan command based on form input
+        const args = ["-p", values.input1];
+        if (verboseMode) {
+            args.push("-v"); // Add verbose mode option if enabled
         }
+
+        // Execute the Masscan command via helper method and handle its output or potential errors
+        CommandHelper.runCommandGetPidAndOutput(
+            "masscan",
+            [...args, "--no-color"],
+            handleProcessData,
+            handleProcessTermination
+        )
+            .then(() => {
+                // Deactivate loading state
+                setLoading(false);
+            })
+            .catch((error) => {
+                // Display any errors encountered during command execution
+                setOutput(`Error: ${error.message}`);
+                // Deactivate loading state
+                setLoading(false);
+            });
     };
 
-     /**
+    /**
      * Handles the completion of output saving by updating state variables.
      */
-     const handleSaveComplete = () => {
+    const handleSaveComplete = () => {
         setHasSaved(true); // Set hasSaved state to true
         setAllowSave(false); // Disallow further output saving
     };
@@ -83,7 +155,7 @@ const Masscan = () => {
         setAllowSave(false); // Disallow further output saving
     };
 
-    //<ConsoleWrapper output={output} clearOutputCallback={clearOutput} /> prints the terminal on the tool
+    // Render component
     return (
         <RenderComponent
             title={title}
@@ -92,24 +164,28 @@ const Masscan = () => {
             tutorial={tutorial}
             sourceLink={sourceLink}
         >
-        <form onSubmit={form.onSubmit((values) => onSubmit({ ...values, masscanOptions: selectedMasscanOption }))}>
-            <Stack>
-                
-                <NativeSelect
-                    value={selectedMasscanOption}
-                    onChange={(e) => setSelectedMasscanOption(e.target.value)}
-                    title={"Masscan option"}
-                    data={masscanOptions}
-                    required
-                    placeholder={"Pick a Masscan option"}
-                    description={"Type of action to perform"}
+            {!loadingModal && (
+                <InstallationModal
+                    isOpen={opened}
+                    setOpened={setOpened}
+                    feature_description={description}
+                    dependencies={dependencies}
                 />
-                <TextInput label={"Input 1"} {...form.getInputProps("input1")} />
-                <Button type={"submit"}>start masscan</Button>
-                {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
-                <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
-            </Stack>
-        </form>
+            )}
+            <form onSubmit={form.onSubmit(onSubmit)}>
+                <Stack>
+                    {LoadingOverlayAndCancelButton(loading, pid)}
+                    <TextInput label="input1" required {...form.getInputProps("input1")} />
+                    <Checkbox
+                        label="Verbose Mode"
+                        checked={verboseMode}
+                        onChange={(event) => setVerboseMode(event.currentTarget.checked)}
+                    />
+                    <Button type={"submit"}>Start {title}</Button>
+                    {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
+                    <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
+                </Stack>
+            </form>
         </RenderComponent>
     );
 };

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -36,6 +36,7 @@ const Masscan = () => {
     const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state of the modal.
     const [pid, setPid] = useState(""); // State variable to store the process ID of the command execution.
     const [verboseMode, setVerboseMode] = useState(false); // State variable for verbose mode
+    const [checkedTopPorts, setCheckedTopPorts] = useState(false); //State variable for scanning common ports.
 
     // Component Constants
     const title = "Masscan";
@@ -208,12 +209,17 @@ const Masscan = () => {
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
                     {LoadingOverlayAndCancelButton(loading, pid)}
+                    <Checkbox
+                        label={"Scan Common Ports Mode"}
+                        checked={checkedTopPorts}
+                        onChange={(e) => setCheckedTopPorts(e.currentTarget.checked)}
+                    />
                     <TextInput label="IP Address/Range/Subnet" required {...form.getInputProps("targetIP")} />
                     <TextInput label="Port/Port Range" required {...form.getInputProps("targetPort")} />
+                    <TextInput label="Scan Common Ports" required {...form.getInputProps("topPorts")} />
                     <TextInput label="Response Wait Timer" {...form.getInputProps("waitTime")} />
                     <TextInput label="Packet Send Rate" {...form.getInputProps("packetRate")} />
                     <TextInput label="Exclude IP(s)" {...form.getInputProps("excludedIP")} />
-                    <TextInput label="Scan Common Ports" {...form.getInputProps("topPorts")} />
                     <Checkbox
                         label="Verbose Mode"
                         checked={verboseMode}

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -17,6 +17,7 @@ interface FormValuesType {
     targetPort: string;
     waitTime: string;
     packetRate: string;
+    excludedIP: string;
 }
 
 /**
@@ -53,6 +54,7 @@ const Masscan = () => {
             targetPort: "",
             waitTime: "",
             packetRate: "",
+            excludedIP: "",
         },
     });
 
@@ -132,6 +134,11 @@ const Masscan = () => {
         if (values.packetRate) {
             args.push("--rate", values.packetRate);
         }
+
+        // Check if excludedIP has a value and push it to args
+        if (values.excludedIP) {
+            args.push("--exclude", values.excludedIP); // Add verbose mode option if enabled
+        }
         
         if (verboseMode) {
             args.push("-v"); // Add verbose mode option if enabled
@@ -198,6 +205,7 @@ const Masscan = () => {
                     <TextInput label="Port/Port Range" required {...form.getInputProps("targetPort")} />
                     <TextInput label="Response Wait Timer" {...form.getInputProps("waitTime")} />
                     <TextInput label="Packet Send Rate" {...form.getInputProps("packetRate")} />
+                    <TextInput label="Exclude IP(s)" {...form.getInputProps("excludedIP")} />
                     <Checkbox
                         label="Verbose Mode"
                         checked={verboseMode}

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -41,11 +41,18 @@ const Masscan = () => {
 
     // Component Constants
     const title = "Masscan";
-    const description = "Masscan is a...";
+    const description = "Masscan is a network reconnaissance tool designed to scan large IP ranges for open ports and services faster than traditional scanners.";
     const steps =
-        "Step 1: \n" +
-        "Step 2: \n" +
-        "Step 3: \n";
+        "=== Required ===\n" +
+        "Step 1: Input a single IP address or an IP address range/subnet to scan.\n" +
+        "Step 2: Input a port or range of ports to scan. Alternativley check the common ports box and input n number of common ports to scan.\n" +
+        " \n" +
+        "=== Optional ===\n" +
+        "Step 3: Input a wait time to allow Masscan to wait after the last packet is sent to receive any delayed responses.\n" +
+        "Step 4: Input a packet rate to deterine how many packets are sent per second (Slower rates can help avoid detection).\n" +
+        "Step 5: Input a single IP address or an IP address range to exclude from the scan.\n" +
+        "Step 6: Input a network interface to send and recieve packets from during the scan.\n" +
+        "Step 7: Check the verbose checkbox to run the command in verbose mode.\n";
     const sourceLink = ""; // Link to the source code
     const tutorial = ""; // Link to the official documentation/tutorial
     const dependencies = ["masscan"]; // Contains the dependencies required by the component.

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -219,16 +219,16 @@ const Masscan = () => {
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
                     {LoadingOverlayAndCancelButton(loading, pid)}
-                    <Checkbox
-                        label={"Scan Common Ports Mode"}
-                        checked={checkedTopPorts}
-                        onChange={(e) => setCheckedTopPorts(e.currentTarget.checked)}
-                    />
                     <TextInput
                         label="IP Address/Range/Subnet"
                         required
                         {...form.getInputProps("targetIP")}
                         placeholder="e.g. 192.168.1.0"
+                    />
+                    <Checkbox
+                        label={"Scan Common Ports Mode"}
+                        checked={checkedTopPorts}
+                        onChange={(e) => setCheckedTopPorts(e.currentTarget.checked)}
                     />
                     {checkedTopPorts ? (
                         <TextInput

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -140,6 +140,7 @@ const Masscan = () => {
                 // Deactivate loading state
                 setLoading(false);
             });
+            setAllowSave(true);
     };
 
     /**

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -122,6 +122,16 @@ const Masscan = () => {
         // Construct arguments for the Masscan command based on form input
         let args = [];
         args = [values.targetIP, '-p', values.targetPort];
+
+        // Check if waitTime has a value and push it to args
+        if (values.waitTime) {
+            args.push("--wait", values.waitTime);
+        }  
+
+        // Check if packetRate has a value and push it to args
+        if (values.packetRate) {
+            args.push("--rate", values.packetRate);
+        }
         
         if (verboseMode) {
             args.push("-v"); // Add verbose mode option if enabled

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -38,6 +38,7 @@ const Masscan = () => {
     const [pid, setPid] = useState(""); // State variable to store the process ID of the command execution.
     const [verboseMode, setVerboseMode] = useState(false); // State variable for verbose mode
     const [checkedTopPorts, setCheckedTopPorts] = useState(false); //State variable for scanning common ports.
+    const [checkedBannerGrabbing, setCheckedBannerGrabbing] = useState(false); //State variable for banner grabbing.
 
     // Component Constants
     const title = "Masscan";
@@ -53,7 +54,8 @@ const Masscan = () => {
         "Step 4: Input a packet rate to deterine how many packets are sent per second (Slower rates can help avoid detection).\n" +
         "Step 5: Input a single IP address or an IP address range to exclude from the scan.\n" +
         "Step 6: Input a network interface to send and recieve packets from during the scan.\n" +
-        "Step 7: Check the verbose checkbox to run the command in verbose mode.\n";
+        "Step 7: Check the banner grabbing checkbox to attempt to identify services running on scanned ports.\n";
+    ("Step 8: Check the verbose checkbox to run the command in verbose mode.\n");
     const sourceLink = ""; // Link to the source code
     const tutorial = ""; // Link to the official documentation/tutorial
     const dependencies = ["masscan"]; // Contains the dependencies required by the component.
@@ -163,6 +165,10 @@ const Masscan = () => {
             args.push("--interface", values.interface);
         }
 
+        if (checkedBannerGrabbing) {
+            args.push("--banner"); // Add banner grabbing if option is enabled
+        }
+
         if (verboseMode) {
             args.push("-v"); // Add verbose mode option if enabled
         }
@@ -256,6 +262,11 @@ const Masscan = () => {
                         label="Select Network Interface"
                         {...form.getInputProps("interface")}
                         placeholder="e.g. eth0"
+                    />
+                    <Checkbox
+                        label="Banner Grabbing"
+                        checked={checkedBannerGrabbing}
+                        onChange={(event) => setCheckedBannerGrabbing(event.currentTarget.checked)}
                     />
                     <Checkbox
                         label="Verbose Mode"

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -19,6 +19,7 @@ interface FormValuesType {
     packetRate: string;
     excludedIP: string;
     topPorts: string;
+    interface: string;
 }
 
 /**
@@ -58,6 +59,7 @@ const Masscan = () => {
             packetRate: "",
             excludedIP: "",
             topPorts: "",
+            interface: "",
         },
     });
 
@@ -147,6 +149,11 @@ const Masscan = () => {
         if (values.topPorts) {
             args.push("--top-ports", values.topPorts);
         }
+
+        // Check if interface has a value and push it to args
+        if (values.topPorts) {
+            args.push("--interface", values.interface);
+        }
         
         if (verboseMode) {
             args.push("-v"); // Add verbose mode option if enabled
@@ -223,6 +230,7 @@ const Masscan = () => {
                     <TextInput label="Response Wait Timer" {...form.getInputProps("waitTime")} />
                     <TextInput label="Packet Send Rate" {...form.getInputProps("packetRate")} />
                     <TextInput label="Exclude IP(s)" {...form.getInputProps("excludedIP")} />
+                    <TextInput label="Select Network Interface" {...form.getInputProps("interface")} />
                     <Checkbox
                         label="Verbose Mode"
                         checked={verboseMode}

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -228,16 +228,16 @@ const Masscan = () => {
                         checked={checkedTopPorts}
                         onChange={(e) => setCheckedTopPorts(e.currentTarget.checked)}
                     />
-                    <TextInput label="IP Address/Range/Subnet" required {...form.getInputProps("targetIP")} />
+                    <TextInput label="IP Address/Range/Subnet" required {...form.getInputProps("targetIP")} placeholder="e.g. 192.168.1.0" />
                     {checkedTopPorts ? (
-                        <TextInput label="Scan Common Ports" required {...form.getInputProps("topPorts")} />
+                        <TextInput label="Scan Common Ports" required {...form.getInputProps("topPorts")} placeholder="e.g. 100" />
                     ):(
-                        <TextInput label="Port/Port Range" required {...form.getInputProps("targetPort")} />
+                        <TextInput label="Port/Port Range" required {...form.getInputProps("targetPort")} placeholder="e.g. 80 or 80-100" />
                     )}
-                    <TextInput label="Response Wait Timer" {...form.getInputProps("waitTime")} />
-                    <TextInput label="Packet Send Rate" {...form.getInputProps("packetRate")} />
-                    <TextInput label="Exclude IP(s)" {...form.getInputProps("excludedIP")} />
-                    <TextInput label="Select Network Interface" {...form.getInputProps("interface")} />
+                    <TextInput label="Response Wait Timer" {...form.getInputProps("waitTime")} placeholder="e.g. 5" />
+                    <TextInput label="Packet Send Rate" {...form.getInputProps("packetRate")} placeholder="e.g. 1000" />
+                    <TextInput label="Exclude IP(s)" {...form.getInputProps("excludedIP")} placeholder="e.g. 192.168.1.4" />
+                    <TextInput label="Select Network Interface" {...form.getInputProps("interface")} placeholder="e.g. eth0" />
                     <Checkbox
                         label="Verbose Mode"
                         checked={verboseMode}

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -1,0 +1,4 @@
+const Masscan = () => {
+    return null;
+}
+export default Masscan;

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -1,4 +1,117 @@
-const Masscan = () => {
-    return null;
+import { Button, NativeSelect, Stack, TextInput } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useState } from "react";
+import { CommandHelper } from "../../utils/CommandHelper";
+import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
+import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile";
+import { RenderComponent } from "../UserGuide/UserGuide";
+
+// Component Constants.
+const title = "Masscan"; // Title of the component.
+const description = "Masscan is a tool used to..."; // Description of the component.
+const steps =
+    "Step 1: ...\n" +
+    "Step 2: ...";
+const sourceLink = ""; // Link to the source code (or Kali Tools).
+const tutorial = ""; // Link to the official documentation/tutorial.
+const dependencies = ["masscan"]; // Contains the dependencies required by the component.
+
+//Variables
+interface FormValuesType { //Relevant form values to be added as Masscan options are added
+    masscanOptions: string; 
 }
+
+//Masscan Options
+const masscanOptions = [ //More options to be added (version check could be kept?)
+    "Version Check"
+];
+
+const Masscan = () => {
+    var [output, setOutput] = useState("");
+    const [selectedMasscanOption, setSelectedMasscanOption] = useState("");
+    const [allowSave, setAllowSave] = useState(false); // State variable to allow saving of output
+    const [hasSaved, setHasSaved] = useState(false); // State variable to indicate if output has been saved
+    const [loading, setLoading] = useState(false); // State variable to indicate loading state
+
+    let form = useForm({ //Relevant form values to be added as Masscan options are added
+        initialValues: {
+            input1: "",
+        },
+    });
+
+    const onSubmit = async (values: FormValuesType) => {
+        // Set loading state to true and disallow output saving
+        setLoading(true);
+        setAllowSave(false);
+
+        let args = [``];
+
+        //Switch case
+        switch (values.masscanOptions) {
+            case "Version Check": //This version check option is a baseline to test that Masscan functions
+                args = [`--version`];
+
+                try {
+                    let output = await CommandHelper.runCommand("masscan", args);
+                    setOutput(output);
+                } catch (e: any) {
+                    setOutput(e);
+                } finally{
+                    // Set loading state to false and allow output saving
+                    setLoading(false);
+                    setAllowSave(true);
+                }
+
+                break;
+        }
+    };
+
+     /**
+     * Handles the completion of output saving by updating state variables.
+     */
+     const handleSaveComplete = () => {
+        setHasSaved(true); // Set hasSaved state to true
+        setAllowSave(false); // Disallow further output saving
+    };
+
+    /**
+     * Clears the command output and resets state variables related to output saving.
+     */
+    const clearOutput = () => {
+        setOutput(""); // Clear the command output
+        setHasSaved(false); // Reset hasSaved state
+        setAllowSave(false); // Disallow further output saving
+    };
+
+    //<ConsoleWrapper output={output} clearOutputCallback={clearOutput} /> prints the terminal on the tool
+    return (
+        <RenderComponent
+            title={title}
+            description={description}
+            steps={steps}
+            tutorial={tutorial}
+            sourceLink={sourceLink}
+        >
+        <form onSubmit={form.onSubmit((values) => onSubmit({ ...values, masscanOptions: selectedMasscanOption }))}>
+            <Stack>
+                
+                <NativeSelect
+                    value={selectedMasscanOption}
+                    onChange={(e) => setSelectedMasscanOption(e.target.value)}
+                    title={"Masscan option"}
+                    data={masscanOptions}
+                    required
+                    placeholder={"Pick a Masscan option"}
+                    description={"Type of action to perform"}
+                />
+                <TextInput label={"Input 1"} {...form.getInputProps("input1")} />
+                <Button type={"submit"}>start masscan</Button>
+                {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
+                <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
+            </Stack>
+        </form>
+        </RenderComponent>
+    );
+};
+
 export default Masscan;

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -139,12 +139,12 @@ const Masscan = () => {
 
         // Check if excludedIP has a value and push it to args
         if (values.excludedIP) {
-            args.push("--exclude", values.excludedIP); // Add verbose mode option if enabled
+            args.push("--exclude", values.excludedIP);
         }
 
-        // Check if excludedIP has a value and push it to args
+        // Check if topPorts has a value and push it to args
         if (values.topPorts) {
-            args.push("--top-ports", values.topPorts); // Add verbose mode option if enabled
+            args.push("--top-ports", values.topPorts);
         }
         
         if (verboseMode) {

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -232,7 +232,7 @@ const Masscan = () => {
                     />
                     {checkedTopPorts ? (
                         <TextInput
-                            label="Scan Common Ports"
+                            label="Number of Common Ports"
                             required
                             {...form.getInputProps("topPorts")}
                             placeholder="e.g. 100"

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -13,7 +13,8 @@ import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
  * Represents the form values for the Masscan component.
  */
 interface FormValuesType {
-    input1: string;
+    targetIP: string;
+    targetPort: string;
 }
 
 /**
@@ -46,7 +47,8 @@ const Masscan = () => {
     // Form hook to handle form input
     let form = useForm({
         initialValues: {
-            input1: "",
+            targetIP: "",
+            targetPort: "",
         },
     });
 
@@ -114,7 +116,9 @@ const Masscan = () => {
         setLoading(true);
 
         // Construct arguments for the Masscan command based on form input
-        const args = ["-p", values.input1];
+        let args = [];
+        args = [values.targetIP, '-p', values.targetPort, ];
+        
         if (verboseMode) {
             args.push("-v"); // Add verbose mode option if enabled
         }
@@ -175,7 +179,8 @@ const Masscan = () => {
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
                     {LoadingOverlayAndCancelButton(loading, pid)}
-                    <TextInput label="input1" required {...form.getInputProps("input1")} />
+                    <TextInput label="IP Address/Range/Subnet" required {...form.getInputProps("targetIP")} />
+                    <TextInput label="Port/Port Range" required {...form.getInputProps("targetPort")} />
                     <Checkbox
                         label="Verbose Mode"
                         checked={verboseMode}

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -215,8 +215,11 @@ const Masscan = () => {
                         onChange={(e) => setCheckedTopPorts(e.currentTarget.checked)}
                     />
                     <TextInput label="IP Address/Range/Subnet" required {...form.getInputProps("targetIP")} />
-                    <TextInput label="Port/Port Range" required {...form.getInputProps("targetPort")} />
-                    <TextInput label="Scan Common Ports" required {...form.getInputProps("topPorts")} />
+                    {checkedTopPorts ? (
+                        <TextInput label="Scan Common Ports" required {...form.getInputProps("topPorts")} />
+                    ):(
+                        <TextInput label="Port/Port Range" required {...form.getInputProps("targetPort")} />
+                    )}
                     <TextInput label="Response Wait Timer" {...form.getInputProps("waitTime")} />
                     <TextInput label="Packet Send Rate" {...form.getInputProps("packetRate")} />
                     <TextInput label="Exclude IP(s)" {...form.getInputProps("excludedIP")} />

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -54,8 +54,8 @@ const Masscan = () => {
         "Step 4: Input a packet rate to deterine how many packets are sent per second (Slower rates can help avoid detection).\n" +
         "Step 5: Input a single IP address or an IP address range to exclude from the scan.\n" +
         "Step 6: Input a network interface to send and recieve packets from during the scan.\n" +
-        "Step 7: Check the banner grabbing checkbox to attempt to identify services running on scanned ports.\n";
-    ("Step 8: Check the verbose checkbox to run the command in verbose mode.\n");
+        "Step 7: Check the banner grabbing checkbox to attempt to identify services running on scanned ports.\n" +
+        "Step 8: Check the verbose checkbox to run the command in verbose mode.\n";
     const sourceLink = ""; // Link to the source code
     const tutorial = ""; // Link to the official documentation/tutorial
     const dependencies = ["masscan"]; // Contains the dependencies required by the component.

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -76,6 +76,7 @@ import WhatWeb from "./WhatWeb/WhatWeb";
 import Sublist3r from "./Sublist3r/Sublist3r";
 import Arpscan from "./ArpScan/ArpScan";
 import Whois from "./Whois/Whois";
+import Masscan from "./Masscan/Masscan";
 
 export interface RouteProperties {
     name: string;
@@ -653,6 +654,15 @@ export const ROUTES: RouteProperties[] = [
             "WPScan is an enumeration tool that scans remote WordPress installations in attempt to identify security issues.",
         category: "Web Application Testing",
     },
+    {
+        name: "Masscan",
+        path: "/tools/Masscan",
+        element: <Masscan />,
+        description:
+            "Masscan is a quick and effective port scanning tool used for network reconnaissance.",
+        category: "Network Scanning and Enumeration",
+    },
+
 ];
 export function getTools() {
     return ROUTES.filter((route) => route.path.startsWith("/tools/"));

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -483,6 +483,14 @@ export const ROUTES: RouteProperties[] = [
         category: "Password Cracking and Authentication Testing",
     },
     {
+        name: "Masscan",
+        path: "/tools/Masscan",
+        element: <Masscan />,
+        description:
+            "Masscan is a quick and effective port scanning tool used for network reconnaissance.",
+        category: "Network Scanning and Enumeration",
+    },
+    {
         name: "Metagoofil",
         path: "/tools/metagoofil",
         element: <Metagoofil />,
@@ -653,14 +661,6 @@ export const ROUTES: RouteProperties[] = [
         description:
             "WPScan is an enumeration tool that scans remote WordPress installations in attempt to identify security issues.",
         category: "Web Application Testing",
-    },
-    {
-        name: "Masscan",
-        path: "/tools/Masscan",
-        element: <Masscan />,
-        description:
-            "Masscan is a quick and effective port scanning tool used for network reconnaissance.",
-        category: "Network Scanning and Enumeration",
     },
 
 ];

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -486,8 +486,7 @@ export const ROUTES: RouteProperties[] = [
         name: "Masscan",
         path: "/tools/Masscan",
         element: <Masscan />,
-        description:
-            "Masscan is a quick and effective port scanning tool used for network reconnaissance.",
+        description: "Masscan is a quick and effective port scanning tool used for network reconnaissance.",
         category: "Network Scanning and Enumeration",
     },
     {
@@ -662,7 +661,6 @@ export const ROUTES: RouteProperties[] = [
             "WPScan is an enumeration tool that scans remote WordPress installations in attempt to identify security issues.",
         category: "Web Application Testing",
     },
-
 ];
 export function getTools() {
     return ROUTES.filter((route) => route.path.startsWith("/tools/"));


### PR DESCRIPTION
**### Tool Description:**
Masscan is a network reconnaissance tool designed to scan large IP ranges for open ports and services faster than traditional scanners.

**### Tool Features:**
In its current state, the Masscan tool within DDT scans for open ports on specified IP addresses and has the following configurations:

1. Input a single IP address or an IP address range/subnet to scan.
2. Input a port or range of ports to scan. Alternatively, check the common ports box and input n number of common ports to scan.
3. Input a wait time to allow Masscan to wait after the last packet is sent to receive any delayed responses.
4. Input a packet rate to determine how many packets are sent per second (slower rates can help avoid detection).
5. Input a single IP address or an IP address range to exclude from the scan.
6. Input a network interface to send and receive packets from during the scan.
7. Check the banner grabbing checkbox to attempt to identify services running on scanned ports.
8. Check the verbose checkbox to run the command in verbose mode.