### PR TITLE
Issue #692 Fix

### DIFF
--- a/src/components/Arpaname/arpaname.tsx
+++ b/src/components/Arpaname/arpaname.tsx
@@ -42,7 +42,7 @@ const ArpanameTool = () => {
         "Step 3: View the output block to see the results. ";
     const sourceLink = ""; // Link to the source code (or Kali Tools).
     const tutorial = ""; // Link to the official documentation/tutorial.
-    const dependencies = ["bind9"];
+    const dependencies = ["arpaname"];
 
     // Check for command availability on component mount
     useEffect(() => {

--- a/src/components/Rainbowcrack/Rainbowcrack.tsx
+++ b/src/components/Rainbowcrack/Rainbowcrack.tsx
@@ -42,7 +42,7 @@ const RainbowCrack = () => {
         "The user can even save the output to a file by assigning a file-name under 'save output to file' option."; // Steps to use the component.
     const sourceLink = ""; // Link to the source code (or RainbowCrack documentation).
     const tutorial = ""; // Link to the official documentation/tutorial.
-    const dependencies = ["rainbowcrack"]; // Dependencies required by the component.
+    const dependencies = ["rcrack"]; // Dependencies required by the component.
 
     // Form hook to handle form input.
     const form = useForm({


### PR DESCRIPTION
The dependencies variable for each of the tools is used by the Deakin Detonator Toolkit to verify that a given tool is installed on a system. The dependencies variables for the rainbowcrack and arpaname tools were incorrect, preventing users for accessing the tools regardless of if they were correctly installed or not. This pull request has fixed the values of the variables so that the rainbowcrack and arpaname tools work correctly.