### PR TITLE
846 feature request enhancement of the amap tool

### DIFF
--- a/src/components/Amap/Amap.tsx
+++ b/src/components/Amap/Amap.tsx
@@ -16,6 +16,8 @@ interface FormValuesType {
     target: string;
     port: string;
     options: string;
+    connectionTimeout: string;
+    responseTimeout: string;
 }
 
 /**

--- a/src/components/Amap/Amap.tsx
+++ b/src/components/Amap/Amap.tsx
@@ -131,7 +131,6 @@ const AMAP = () => {
             values.port,
             `-T ${values.connectionTimeout}`,
             `-t ${values.responseTimeout}`,
-            values.options,
         ];
 
         // Execute the amap command via helper method and handle its output or potential errors
@@ -178,7 +177,16 @@ const AMAP = () => {
                     {LoadingOverlayAndCancelButton(loading, pid)}
                     <TextInput label={"Target Host"} required {...form.getInputProps("target")} />
                     <TextInput label={"Port(s)"} required {...form.getInputProps("port")} />
-                    <TextInput label={"Additional Options"} {...form.getInputProps("options")} />
+                    <TextInput
+                        label={"Connection Timeout (seconds)"}
+                        required
+                        {...form.getInputProps("connectionTimeout")}
+                    />
+                    <TextInput
+                        label={"Response Timeout (seconds)"}
+                        required
+                        {...form.getInputProps("responseTimeout")}
+                    />
                     {SaveOutputToTextFile(output)}
                     <Button type={"submit"}>Start Scan</Button>
                     <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />

--- a/src/components/Amap/Amap.tsx
+++ b/src/components/Amap/Amap.tsx
@@ -125,7 +125,14 @@ const AMAP = () => {
         setLoading(true);
 
         // Construct arguments for the amap command based on form input
-        const args = [values.target, "-bqv", values.port, values.options];
+        const args = [
+            values.target,
+            "-bqv",
+            values.port,
+            `-T ${values.connectionTimeout}`,
+            `-t ${values.responseTimeout}`,
+            values.options,
+        ];
 
         // Execute the amap command via helper method and handle its output or potential errors
         CommandHelper.runCommandGetPidAndOutput("amap", args, handleProcessData, handleProcessTermination)

--- a/src/components/Amap/Amap.tsx
+++ b/src/components/Amap/Amap.tsx
@@ -52,6 +52,8 @@ const AMAP = () => {
             target: "",
             port: "",
             options: "",
+            connectionTimeout: "10",
+            responseTimeout: "10",
         },
     });
 


### PR DESCRIPTION
**Summary of Changes:**
This PR introduces two new configurable timeout settings to the AMAP tool's UI:

Connection Timeout (-T): Specifies the time (in seconds) to wait for a connection to establish before timing out.
Response Timeout (-t): Specifies the time (in seconds) to wait for a response after the connection is established.

**Key Changes:**
UI Modifications:
- Added two new input fields to the form:
- Connection Timeout: Allows the user to set how long AMAP waits for a connection.
- Response Timeout: Allows the user to set how long AMAP waits for a service to respond after the connection is made.
- Default values are set to 5 seconds for both timeouts but can be adjusted by the user.

Command Execution:
- Updated the AMAP command with the appropriate flags:
- -T <seconds> for the Connection Timeout.
- -t <seconds> for the Response Timeout.
- These values are dynamically passed to the AMAP tool based on the user input.

Validation:

- Both timeout fields enforce numerical input, ensuring the values are valid for execution.
- Why These Changes?:
Timeout settings allow users to adjust the scanning process based on their network conditions:

- Slow Networks: Increase the timeouts to give the services more time to respond.
- Aggressive Scans: Reduce the timeouts for faster feedback in environments where network latency is low.
- By offering these options in the UI, users have finer control over the speed and behavior of their AMAP scans, making the tool more adaptable to various environments.