### PR TITLE
834 Install script does not include install_exploits.sh

### DIFF
--- a/install-update-media/setup_ddt.sh
+++ b/install-update-media/setup_ddt.sh
@@ -59,5 +59,8 @@ fi
 # Install Yarn dependencies
 yarn install
 
+# Move exploits to DDT directory
+chmod +x install-update-media/install_exploits.sh && ./install-update-media/install_exploits.sh
+
 # Modify start script permissions and start application
 chmod +x install-update-media/start-ddt.sh && ./install-update-media/start-ddt.sh


### PR DESCRIPTION
Added a line install the `setup_ddt.sh` script that will also run `install_exploits.sh` so the exploits will be located in their intended location. I'm adding this into the main installation script as many contributors run into the issue of exploits not being located where they should be as they have missed the extra installation step. This will have it automatically run to streamline installation further.