### PR TITLE
833 Non-popup search box non-functional

### DIFF
--- a/src/components/Spotlight/Spotlight.tsx
+++ b/src/components/Spotlight/Spotlight.tsx
@@ -58,7 +58,6 @@ function Search() {
             searchPlaceholder="Search..."
             shortcut="mod + shift + 1"
             nothingFoundMessage="Nothing found..."
-            returnFocus={false}
         >
             <SpotlightControl />
         </SpotlightProvider>

--- a/src/components/Spotlight/Spotlight.tsx
+++ b/src/components/Spotlight/Spotlight.tsx
@@ -13,10 +13,10 @@ function SpotlightControl() {
     not get this to work.
     */
     const handleClick = (e: React.MouseEvent<HTMLInputElement>) => {
+        openSpotlight();
         if (e.currentTarget) {
             e.currentTarget.blur();
         }
-        openSpotlight();
     };
 
     return (
@@ -58,6 +58,7 @@ function Search() {
             searchPlaceholder="Search..."
             shortcut="mod + shift + 1"
             nothingFoundMessage="Nothing found..."
+            returnFocus={false}
         >
             <SpotlightControl />
         </SpotlightProvider>

--- a/src/components/Spotlight/Spotlight.tsx
+++ b/src/components/Spotlight/Spotlight.tsx
@@ -4,7 +4,6 @@ import { openSpotlight, SpotlightProvider } from "@mantine/spotlight";
 import { IconSearch } from "@tabler/icons";
 import { useNavigate } from "react-router-dom";
 import { RouteProperties, ROUTES } from "../RouteWrapper";
-import React, { useEffect, useRef } from "react";
 
 function SpotlightControl() {
     /*

--- a/src/components/Spotlight/Spotlight.tsx
+++ b/src/components/Spotlight/Spotlight.tsx
@@ -4,8 +4,21 @@ import { openSpotlight, SpotlightProvider } from "@mantine/spotlight";
 import { IconSearch } from "@tabler/icons";
 import { useNavigate } from "react-router-dom";
 import { RouteProperties, ROUTES } from "../RouteWrapper";
+import React, { useEffect, useRef } from "react";
 
 function SpotlightControl() {
+    /*
+    TODO This works fine, however it may be better if the input is unfocused
+    by blurring the ref onSpotlightClose in the Search component, but I could
+    not get this to work.
+    */
+    const handleClick = (e: React.MouseEvent<HTMLInputElement>) => {
+        if (e.currentTarget) {
+            e.currentTarget.blur();
+        }
+        openSpotlight();
+    };
+
     return (
         <Input
             variant="filled"
@@ -13,7 +26,7 @@ function SpotlightControl() {
             size="sm"
             icon={<IconSearch size={16} />}
             placeholder="Quick search here..."
-            onClick={() => openSpotlight()}
+            onClick={handleClick}
         />
     );
 }


### PR DESCRIPTION
There were a couple ways this could be fixed but I decided to have the unused search box be unfocused. Originally I was trying to have it unfocused when the search overlay closed but I couldn't get this to work so I opted for it to unfocus after opening the search (Spotlight) overlay.

It is worth noting in newer versions of mantine this component has a prop that disable returning focus.