### PR TITLE
Fixed inconsistent capitalisation and typo

### DIFF
--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -594,7 +594,7 @@ export const ROUTES: RouteProperties[] = [
         path: "/tools/Rainbowcrack",
         element: <Rainbowcrack />,
         description: "A computer program which generates rainbow tables to be used in password cracking.",
-        category: "Password Cracking and Authentication testing",
+        category: "Password Cracking and Authentication Testing",
     },
     {
         name: "SearchSploit",

--- a/src/components/RouteWrapper.tsx
+++ b/src/components/RouteWrapper.tsx
@@ -594,7 +594,7 @@ export const ROUTES: RouteProperties[] = [
         path: "/tools/Rainbowcrack",
         element: <Rainbowcrack />,
         description: "A computer program which generates rainbow tables to be used in password cracking.",
-        category: "Password cracking and Authentication testing",
+        category: "Password Cracking and Authentication testing",
     },
     {
         name: "SearchSploit",
@@ -602,7 +602,7 @@ export const ROUTES: RouteProperties[] = [
         element: <SearchSploit />,
         description:
             "A utility that allows users to search through a vast database of exploits, shellcodes, and security-related papers.",
-        category: "Vulnerabilityy Assessment and Exploitation",
+        category: "Vulnerability Assessment and Exploitation",
     },
     {
         name: "Sherlock",


### PR DESCRIPTION
Fixed a few mistakes in the tool list:
In the "Category" column for "SearchSploit", there's a typo in "Vulnerabilityy" that was changed to "Vulnerability"
In the "Category" column for "Rainbowcrack", there's a typo in "Password cracking and Authentication testing". It should be capitalized as "Password Cracking and Authentication Testing" to match the format of other entries.