### PR TITLE
Fix : 959 - CloudBrute Reference Updated

### DIFF
--- a/src/pages/References.tsx
+++ b/src/pages/References.tsx
@@ -107,6 +107,13 @@ const ReferencesPage = () => {
                         url={"https://www.kali.org/tools/cewl/"}
                     />
                     <Reference
+                        name={"CloudBrute"}
+                        description={
+                            "Cloudbrute is a tool for cloud enumeration and infrastructure discovery in various cloud providers"
+                        }
+                        url={"https://www.kali.org/tools/cloudbrute/"}
+                    />
+                    <Reference
                         name={"CrackMapExec"}
                         description={
                             "CrackMapExec is a post-exploitation tool used for pentesting Windows/Active Directory environments."


### PR DESCRIPTION
Bug Fix: Cloudbrute Not Listed on References Page (https://github.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/issues/959)

Issue: The Cloudbrute tool was missing from the References page of the Deakin Detonator Toolkit project.

Changes Made:

Added Cloudbrute tool to the list of references on the References page (References.tsx).
Ensured that the update is reflected in the UI for better visibility.

How to Test:

Navigate to the References page in the Deakin Detonator Toolkit.
Verify that Cloudbrute is now listed among the available references.
This fix ensures that Cloudbrute is correctly displayed in the reference section as intended.