### PR TITLE
Fix for issues #1007 and #1008, additional bug fixes for Aircrack-ng 

### DIFF
--- a/src/components/AircrackNG/AircrackNG.tsx
+++ b/src/components/AircrackNG/AircrackNG.tsx
@@ -35,8 +35,8 @@ const description = "Aircrack-ng is a tool for cracking WEP and WPA/WPA2 passphr
 const steps =
     "How to use Aircrack-ng:\n\n" +
     "Step 1: Type in the path to wordlist(s) filename(s) including the extension .txt. e.g. 'example.txt'.\n" +
-    "For files containing hexadecimal values, you must put a “h:” in front of the file name.\n";
-"Step 2: Select the target network based on the access point's MAC address.\n" +
+    "For files containing hexadecimal values, you must put a “h:” in front of the file name.\n" +
+    "Step 2: Select the target network based on the access point's MAC address.\n" +
     "Step 3: Type in the name of your text file including the extension .txt. e.g. 'example.txt'.\n" +
     "Step 4: Click 'Start " +
     title +

--- a/src/components/AircrackNG/AircrackNG.tsx
+++ b/src/components/AircrackNG/AircrackNG.tsx
@@ -35,8 +35,8 @@ const description = "Aircrack-ng is a tool for cracking WEP and WPA/WPA2 passphr
 const steps =
     "How to use Aircrack-ng:\n\n" +
     "Step 1: Type in the path to wordlist(s) filename(s) including the extension .txt. e.g. 'example.txt'.\n" +
-    "For files containing hexadecimal values, you must put a “h:” in front of the file name.\n";
-"Step 2: Select the target network based on the access point's MAC address.\n" +
+    "For files containing hexadecimal values, you must put a “h:” in front of the file name.\n" 
+    "Step 2: Select the target network based on the access point's MAC address.\n" +
     "Step 3: Type in the name of your text file including the extension .txt. e.g. 'example.txt'.\n" +
     "Step 4: Click 'Start " +
     title +
@@ -183,7 +183,7 @@ const AircrackNG = () => {
 
         // WEP-specific options
         //if (selectedtype == "WEP") {
-        //if (values.securityType) args.push(`-a 1`, values.securityType);
+            //if (values.securityType) args.push(`-a 1`, values.securityType);
         if (values.BSSID) args.push(`-b`, values.BSSID);
 
         // Advanced WEP options
@@ -194,12 +194,12 @@ const AircrackNG = () => {
 
         // WPA-specific options
         //if (selectedtype == "WPA") {
-        //if (values.securityType) args.push(`-a 2`, values.securityType);
+            //if (values.securityType) args.push(`-a 2`, values.securityType);
         if (values.wordList) args.push(`-w`, values.wordList);
         if (values.ESSID) args.push(`-e`, values.ESSID);
 
-        // Advanced WPA options
-        //if (values.PMKID) args.push(`-I`, values.PMKID);
+            // Advanced WPA options
+            //if (values.PMKID) args.push(`-I`, values.PMKID);
         //}
 
         // Custom Configuration section
@@ -276,7 +276,7 @@ const AircrackNG = () => {
                                 const isChecked = e.currentTarget.checked;
                                 setAdvanceMode(isChecked);
                                 if (!isChecked) {
-                                    setSelectedCharacter("Default"); // Reset character selection when turning off Advanced Mode
+                                    setSelectedCharacter("Default");  // Reset character selection when turning off Advanced Mode
                                 }
                             }}
                         />

--- a/src/components/AircrackNG/AircrackNG.tsx
+++ b/src/components/AircrackNG/AircrackNG.tsx
@@ -35,8 +35,8 @@ const description = "Aircrack-ng is a tool for cracking WEP and WPA/WPA2 passphr
 const steps =
     "How to use Aircrack-ng:\n\n" +
     "Step 1: Type in the path to wordlist(s) filename(s) including the extension .txt. e.g. 'example.txt'.\n" +
-    "For files containing hexadecimal values, you must put a “h:” in front of the file name.\n" 
-    "Step 2: Select the target network based on the access point's MAC address.\n" +
+    "For files containing hexadecimal values, you must put a “h:” in front of the file name.\n";
+"Step 2: Select the target network based on the access point's MAC address.\n" +
     "Step 3: Type in the name of your text file including the extension .txt. e.g. 'example.txt'.\n" +
     "Step 4: Click 'Start " +
     title +
@@ -183,7 +183,7 @@ const AircrackNG = () => {
 
         // WEP-specific options
         //if (selectedtype == "WEP") {
-            //if (values.securityType) args.push(`-a 1`, values.securityType);
+        //if (values.securityType) args.push(`-a 1`, values.securityType);
         if (values.BSSID) args.push(`-b`, values.BSSID);
 
         // Advanced WEP options
@@ -194,12 +194,12 @@ const AircrackNG = () => {
 
         // WPA-specific options
         //if (selectedtype == "WPA") {
-            //if (values.securityType) args.push(`-a 2`, values.securityType);
+        //if (values.securityType) args.push(`-a 2`, values.securityType);
         if (values.wordList) args.push(`-w`, values.wordList);
         if (values.ESSID) args.push(`-e`, values.ESSID);
 
-            // Advanced WPA options
-            //if (values.PMKID) args.push(`-I`, values.PMKID);
+        // Advanced WPA options
+        //if (values.PMKID) args.push(`-I`, values.PMKID);
         //}
 
         // Custom Configuration section
@@ -276,7 +276,7 @@ const AircrackNG = () => {
                                 const isChecked = e.currentTarget.checked;
                                 setAdvanceMode(isChecked);
                                 if (!isChecked) {
-                                    setSelectedCharacter("Default");  // Reset character selection when turning off Advanced Mode
+                                    setSelectedCharacter("Default"); // Reset character selection when turning off Advanced Mode
                                 }
                             }}
                         />


### PR DESCRIPTION
Due to trimester length and the overlaps from the bugs, multiple changes have been made.

Fixed GitHub issues #1007 and #1008.
Gave WEP mode the ability to specify packet capture file.
Removed wordlist option from WEP mode as it is not needed.
Removed required from arguments that are not required for the tool to run.
Removed unused and unnecessary placeholders.
Set selectedModeOption to default to WEP to make sure WEP specific options are loaded in the first time the tool is opened.
Commented out securityType options, as it is made redundant by Aircrack-ng performing that automatically.
Added code to reset advanced mode back to default when option is deselected.

Rewrote construct arguments section as mode specific options were not working and to improve code readability.
Nested if statements were and are still not working and the reason is unclear.
A temporary fix was made to reset the form every time the mode is switched.
Code for mode specific options was left in for a future fix.

Other notes:
There is an option for customConfig that was present in the code, however it has not been implemented.