### PR TITLE
Added missing dependency for ARPANAME in tauri.conf.json

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,6 +48,11 @@
                         "args": true
                     },
                     {
+                        "name": "arpaname",
+                        "cmd": "arpaname",
+                        "args": true
+                    },
+                    {
                         "name": "arp-fingerprint",
                         "cmd": "arp-fingerprint",
                         "args": true


### PR DESCRIPTION
Modified the tauri.conf.json which performs checks for the tools' dependency checks. Added the dependency check for ARPANAME.