### PR TITLE
Fixing Enum4Linux to run on DDT

### DIFF
--- a/src/components/Enum4Linux/Enum4Linux.tsx
+++ b/src/components/Enum4Linux/Enum4Linux.tsx
@@ -99,9 +99,15 @@ const Enum4Linux = () => {
 
         if (osinfo) options = options.concat(" -o");
 
-        const args = values.paramAlt
-            ? [options, values.paramMain, values.paramAlt, values.ipAddress]
-            : [options, values.paramMain, values.ipAddress];
+        let args = []; //Making args mutable, need to check if parameters are provided.
+
+        args.push(options);
+
+        if (values.paramMain) args.push(values.paramMain);
+
+        if (values.paramAlt) args.push(values.paramAlt);
+
+        args.push(values.ipAddress);
 
         CommandHelper.runCommandGetPidAndOutput("enum4linux", args, handleProcessData, handleProcessTermination)
             .then(({ pid, output }) => {


### PR DESCRIPTION
Fixing bug for #1052

So the problem here is that the arguments are not passed properly to the shell. If we see the below, there is a space between -U and the hostname - 
<img width="643" alt="image" src="https://github.com/user-attachments/assets/16d93004-9278-4317-a32e-5b590277c48b">

This happens when the input for the parameters textbox, there is no validation present for this and hence creates a space during command creation.

As a fix added a check to see if value exists before being made part of args var.

Works fine now - 

<img width="827" alt="image" src="https://github.com/user-attachments/assets/c4ed237d-5bd4-4019-badf-64b0d9a9e297">
