### PR TITLE
Rtgen fixes

### DIFF
--- a/src/components/rtgen/rtgen.tsx
+++ b/src/components/rtgen/rtgen.tsx
@@ -3,25 +3,24 @@ import { Button, Stack, TextInput, Checkbox } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { CommandHelper } from "../../utils/CommandHelper";
 import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
-import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile";
 import { RenderComponent } from "../UserGuide/UserGuide";
 import InstallationModal from "../InstallationModal/InstallationModal";
 import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
-//import { LoadingOverlayAndCancelButtonPkexec } from "../OverlayAndCancelButton/OverlayAndCancelButton";
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
+//import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile";
 
 /**
  * Represents the form values for the Rtgen component.
  */
 interface FormValuesType {
-    hashAlgorithm: string;
-    plaintextCharset: string;
-    plaintextLengthMin: string;
-    plaintextLengthMax: string;
-    tableIndex: string,
-    chainLength: string;
-    chainCount: string;
-    partIndex: string,
+    hashAlgorithm: string;          // <hash_algorithm>
+    charset: string;                // <charset>
+    plaintextLengthMin: string;     // <plaintext_length_min>
+    plaintextLengthMax: string;     // <plaintext_length_max>
+    tableIndex: string,             // <table_index>
+    chainLength: string;            // <chain_length>
+    chainCount: string;             // <chain_count>
+    partIndex: string,              // <part_index>
 }
 
 /**
@@ -58,7 +57,7 @@ const Rtgen = () => {
     let form = useForm({
         initialValues: {
             hashAlgorithm: "",
-            plaintextCharset: "",
+            charset: "",
             plaintextLengthMin: "",
             plaintextLengthMax: "",
             tableIndex: "",
@@ -132,25 +131,21 @@ const Rtgen = () => {
         // Construct arguments for the Rtgen command based on form input
         let args = [];
         args = [
-            values.hashAlgorithm,       // <hash_algorithm>
-            values.plaintextCharset,    // <plaintext_charset>
-            values.plaintextLengthMin,  // <plaintext_length_min>
-            values.plaintextLengthMax,  // <plaintext_length_max>
-            values.tableIndex,          // <table_index>
-            values.chainLength,         // <chain_length>
-            values.chainCount,          // <chain_count>
-            values.partIndex,           // <part_index>
+            values.hashAlgorithm,
+            values.charset,
+            values.plaintextLengthMin,
+            values.plaintextLengthMax,
+            values.tableIndex,
+            values.chainLength,
+            values.chainCount,
+            values.partIndex,
         ];
         
         // Execute the Rtgen command via helper method and handle its output or potential errors
         CommandHelper.runCommandWithPkexec("rtgen", args, handleProcessData, handleProcessTermination)
-            .then(() => {
+            .then(({ output }) => {
                 // Update the output with the results of the command execution.
-                //setOutput(output);
-
-                // Store the process ID of the executed command.
-                //setPid(pid);
-
+                setOutput(output);
                 // Deactivate loading state
                 setLoading(false);
             })
@@ -165,11 +160,12 @@ const Rtgen = () => {
 
     /**
      * Handles the completion of output saving by updating state variables.
-     */
+     */ /*
     const handleSaveComplete = () => {
         setHasSaved(true); // Set hasSaved state to true
         setAllowSave(false); // Disallow further output saving
     };
+    */
 
     /**
      * Clears the command output and resets state variables related to output saving.
@@ -207,9 +203,9 @@ const Rtgen = () => {
                         placeholder="e.g., MD5"
                     />
                     <TextInput
-                        label="Plaintext Charset"
+                        label="Character set"
                         required
-                        {...form.getInputProps("plaintextCharset")}
+                        {...form.getInputProps("charset")}
                         placeholder="e.g., alphanumeric"
                     />
                     <TextInput
@@ -255,7 +251,7 @@ const Rtgen = () => {
                         placeholder="e.g., 0"
                     />
                     <Button type={"submit"}>Generate {title}</Button>
-                    {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
+                    {/* {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)} */}
                     <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
                 </Stack>
             </form>

--- a/src/components/rtgen/rtgen.tsx
+++ b/src/components/rtgen/rtgen.tsx
@@ -7,17 +7,21 @@ import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFil
 import { RenderComponent } from "../UserGuide/UserGuide";
 import InstallationModal from "../InstallationModal/InstallationModal";
 import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
+//import { LoadingOverlayAndCancelButtonPkexec } from "../OverlayAndCancelButton/OverlayAndCancelButton";
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 
 /**
  * Represents the form values for the Rtgen component.
  */
 interface FormValuesType {
-    plaintextCharset: string;
     hashAlgorithm: string;
+    plaintextCharset: string;
+    plaintextLengthMin: string;
+    plaintextLengthMax: string;
+    tableIndex: string,
     chainLength: string;
-    tableSize: string;
-    outputFileName: string;
+    chainCount: string;
+    partIndex: string,
 }
 
 /**
@@ -53,14 +57,17 @@ const Rtgen = () => {
     // Form hook to handle form input
     let form = useForm({
         initialValues: {
-            plaintextCharset: "",
             hashAlgorithm: "",
+            plaintextCharset: "",
+            plaintextLengthMin: "",
+            plaintextLengthMax: "",
+            tableIndex: "",
             chainLength: "",
-            tableSize: "",
-            outputFileName: "",
+            chainCount: "",
+            partIndex: "",
         },
     });
-
+    
     useEffect(() => {
         // Check if the command is available and set the state variables accordingly.
         checkAllCommandsAvailability(dependencies)
@@ -97,8 +104,10 @@ const Rtgen = () => {
             // If the process was successful, display a success message.
             if (code === 0) {
                 handleProcessData("\nProcess completed successfully.");
+            // If the process was terminated due to a signal, display the signal code.
             } else if (signal === 15) {
                 handleProcessData("\nProcess was manually terminated.");
+            // If the process was terminated with an error, display the exit code and signal code.
             } else {
                 handleProcessData(`\nProcess terminated with exit code: ${code} and signal code: ${signal}`);
             }
@@ -123,21 +132,25 @@ const Rtgen = () => {
         // Construct arguments for the Rtgen command based on form input
         let args = [];
         args = [
-            "--charset",
-            values.plaintextCharset,
-            "--hash",
-            values.hashAlgorithm,
-            "--chains",
-            values.chainLength,
-            "--table-size",
-            values.tableSize,
-            "--output",
-            values.outputFileName,
+            values.hashAlgorithm,       // <hash_algorithm>
+            values.plaintextCharset,    // <plaintext_charset>
+            values.plaintextLengthMin,  // <plaintext_length_min>
+            values.plaintextLengthMax,  // <plaintext_length_max>
+            values.tableIndex,          // <table_index>
+            values.chainLength,         // <chain_length>
+            values.chainCount,          // <chain_count>
+            values.partIndex,           // <part_index>
         ];
-
+        
         // Execute the Rtgen command via helper method and handle its output or potential errors
         CommandHelper.runCommandWithPkexec("rtgen", args, handleProcessData, handleProcessTermination)
             .then(() => {
+                // Update the output with the results of the command execution.
+                //setOutput(output);
+
+                // Store the process ID of the executed command.
+                //setPid(pid);
+
                 // Deactivate loading state
                 setLoading(false);
             })
@@ -188,34 +201,58 @@ const Rtgen = () => {
                 <Stack>
                     {LoadingOverlayAndCancelButton(loading, pid)}
                     <TextInput
-                        label="Plaintext Charset"
-                        required
-                        {...form.getInputProps("plaintextCharset")}
-                        placeholder="e.g., alphanumeric"
-                    />
-                    <TextInput
                         label="Hash Algorithm"
                         required
                         {...form.getInputProps("hashAlgorithm")}
                         placeholder="e.g., MD5"
                     />
                     <TextInput
+                        label="Plaintext Charset"
+                        required
+                        {...form.getInputProps("plaintextCharset")}
+                        placeholder="e.g., alphanumeric"
+                    />
+                    <TextInput
+                        label="Minimum Plaintext Length"
+                        required
+                        type="number"
+                        {...form.getInputProps("plaintextLengthMin")}
+                        placeholder="e.g., 1"
+                    />
+                    <TextInput
+                        label="Maximum Plaintext Length"
+                        required
+                        type="number"
+                        {...form.getInputProps("plaintextLengthMax")}
+                        placeholder="e.g., 7"
+                    />
+                    <TextInput
+                        label="Table Index"
+                        required
+                        type="number"
+                        {...form.getInputProps("tableIndex")}
+                        placeholder="e.g., 0"
+                    />
+                    <TextInput
                         label="Chain Length"
                         required
+                        type="number"
                         {...form.getInputProps("chainLength")}
                         placeholder="e.g., 1000"
                     />
                     <TextInput
-                        label="Table Size"
+                        label="Chain Count"
                         required
-                        {...form.getInputProps("tableSize")}
+                        type="number"
+                        {...form.getInputProps("chainCount")}
                         placeholder="e.g., 100000"
                     />
                     <TextInput
-                        label="Output File Name"
+                        label="Part Index"
                         required
-                        {...form.getInputProps("outputFileName")}
-                        placeholder="e.g., rainbow_table.rt"
+                        type="number"
+                        {...form.getInputProps("partIndex")}
+                        placeholder="e.g., 0"
                     />
                     <Button type={"submit"}>Generate {title}</Button>
                     {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}

--- a/src/components/rtgen/rtgen.tsx
+++ b/src/components/rtgen/rtgen.tsx
@@ -13,14 +13,14 @@ import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
  * Represents the form values for the Rtgen component.
  */
 interface FormValuesType {
-    hashAlgorithm: string;          // <hash_algorithm>
-    charset: string;                // <charset>
-    plaintextLengthMin: string;     // <plaintext_length_min>
-    plaintextLengthMax: string;     // <plaintext_length_max>
-    tableIndex: string,             // <table_index>
-    chainLength: string;            // <chain_length>
-    chainCount: string;             // <chain_count>
-    partIndex: string,              // <part_index>
+    hashAlgorithm: string; // <hash_algorithm>
+    charset: string; // <charset>
+    plaintextLengthMin: string; // <plaintext_length_min>
+    plaintextLengthMax: string; // <plaintext_length_max>
+    tableIndex: string; // <table_index>
+    chainLength: string; // <chain_length>
+    chainCount: string; // <chain_count>
+    partIndex: string; // <part_index>
 }
 
 /**
@@ -66,7 +66,7 @@ const Rtgen = () => {
             partIndex: "",
         },
     });
-    
+
     useEffect(() => {
         // Check if the command is available and set the state variables accordingly.
         checkAllCommandsAvailability(dependencies)
@@ -103,10 +103,10 @@ const Rtgen = () => {
             // If the process was successful, display a success message.
             if (code === 0) {
                 handleProcessData("\nProcess completed successfully.");
-            // If the process was terminated due to a signal, display the signal code.
+                // If the process was terminated due to a signal, display the signal code.
             } else if (signal === 15) {
                 handleProcessData("\nProcess was manually terminated.");
-            // If the process was terminated with an error, display the exit code and signal code.
+                // If the process was terminated with an error, display the exit code and signal code.
             } else {
                 handleProcessData(`\nProcess terminated with exit code: ${code} and signal code: ${signal}`);
             }
@@ -140,7 +140,7 @@ const Rtgen = () => {
             values.chainCount,
             values.partIndex,
         ];
-        
+
         // Execute the Rtgen command via helper method and handle its output or potential errors
         CommandHelper.runCommandWithPkexec("rtgen", args, handleProcessData, handleProcessTermination)
             .then(({ output }) => {


### PR DESCRIPTION
- Removed hardcoded parameters.
- Added additional parameters that rtgen requires.
- Full command now appears in the terminal.
- Commented out SaveOutputToTextFile as it is not compatible with this tool.

Additional Notes:
- Rainbow tables are saved to /usr/share/rainbowcrack, there is no built-in way to change this.
- User guide needs to be updated with new parameters
- As a consequence of showing the command in the terminal, 'pkexec' also appears before it. I am unsure how to remove this.