### PR TITLE
Adding Attack Vector guides

### DIFF
--- a/src/components/CVE-2021-41773/CVE-2021-41773.tsx
+++ b/src/components/CVE-2021-41773/CVE-2021-41773.tsx
@@ -53,7 +53,7 @@ export function CVE202141773() {
         "Step 5: Click Exploit to commence the RCE’s operation.\n\n" +
         "Step 6: View the Output block below to view the results of the attack vector's execution.";
     const sourceLink = "cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-41773"; // Link to the source code (or Kali Tools).
-    const tutorial = ""; // Link to the official documentation/tutorial.
+    const tutorial = "https://docs.google.com/document/d/1wSXTUBGtBAWfLhImpCHkSCjiTQjneAOz/edit?usp=sharing"; // Link to the official documentation/tutorial.
     const dependencies = ["python3"]; // Contains the dependencies required by the component.
 
     // Form hook to handle form input.

--- a/src/components/CVE-2021-44228/CVE-2021-44228.tsx
+++ b/src/components/CVE-2021-44228/CVE-2021-44228.tsx
@@ -35,7 +35,7 @@ const steps =
     "Step 4: Click Exploit to commence the exploits operation.\n" +
     "Step 5: View the Output block below to view the results of the attack vectors execution.";
 const sourceLink = "cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228"; // Link to the source code (or Kali Tools).
-const tutorial = ""; // Link to the official documentation/tutorial.
+const tutorial = "https://docs.google.com/document/d/1vPBporizROLhWt4EycJ53jo7Bjioh-K4/edit?usp=sharing"; // Link to the official documentation/tutorial.
 const dependencies = ["python3"]; // Contains the dependencies required by the component.
 
 /**


### PR DESCRIPTION
I have written documents for two of the attack vectors - CVE2021-41773 and CVE2021-44228. 
These documents describe:
- when the vulnerability was discovered,
- how serious it is,
- how it works, 
- and how the DDT demonstrates this vulnerability. 
These sit within the tutorials tab for each attack vector and will help DDT users to have a greater understanding of the concepts being demonstrated in this section of the application.
