### PR TITLE
Filepicker netcat implementation

### DIFF
--- a/src/components/Hydra/Hydra.tsx
+++ b/src/components/Hydra/Hydra.tsx
@@ -8,6 +8,7 @@ import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/Overlay
 import { RenderComponent } from "../UserGuide/UserGuide";
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 import InstallationModal from "../InstallationModal/InstallationModal";
+import { FilePicker } from "../FileHandler/FilePicker";
 
 /**
  * Represents the form values for the Hydra component.
@@ -24,6 +25,16 @@ interface FormValuesType {
     config: string;
     optionalConfig: string;
 }
+
+//Deals with the generatedfilepath unique identifier that is added at the end of a file
+const cleanFileName = (filePath: string): string => {
+    // Split the file name by the underscore (_) and keep the first part (before the timestamp/ID)
+    const parts = filePath.split("_");
+
+    // Keep only the base file name (before the timestamp and unique identifier)
+    const baseFileName = parts[0];
+    return baseFileName;
+};
 
 /**
  * The Hydra component.
@@ -42,6 +53,7 @@ const Hydra = () => {
     const [opened, setOpened] = useState(!isCommandAvailable); // State variable to indicate loading state of the modal.
     const [allowSave, setAllowSave] = useState(false); // State variable to indicate if saving is allowed
     const [hasSaved, setHasSaved] = useState(false); // State variable to indicate if the output has been saved
+    const [fileNames, setFileNames] = useState<string[]>([]); // State variable to store the file names.
 
     // Component Constants.
     const title = "Hydra"; // Title of the component.
@@ -199,17 +211,25 @@ const Hydra = () => {
         // Disallow saving until the tool's execution is complete
         setAllowSave(false);
 
+        const baseFilePath = "/home/kali";
+
         // Construct arguments for the  Hydra command based on form input
         const args = [];
         if (selectedLoginInput === "Single Login") {
             args.push(`-l`, `${values.loginArgs}`);
         } else if (selectedLoginInput === "File") {
-            args.push(`-L`, `${values.loginArgs}`);
+            const fileToSend = fileNames[0]; // Take the first file from the file picker
+            const cleanName = cleanFileName(fileToSend); // Clean the file name (strip unique identifier)
+            const dataUploadPath = `${baseFilePath}/${cleanName}`;
+            args.push("-l", dataUploadPath);
         }
         if (selectedPasswordInput === "Single Password") {
             args.push(`-p`, `${values.passwordArgs}`);
         } else if (selectedPasswordInput === "File") {
-            args.push(`-P`, `${values.passwordArgs}`);
+            const fileToSend = fileNames[0]; // Take the first file for passwords
+            const cleanName = cleanFileName(fileToSend);
+            const dataUploadPath = `${baseFilePath}/${cleanName}`;
+            args.push("-P", dataUploadPath);
         } else if (selectedPasswordInput === "Character Set") {
             args.push(`-x`, `${values.passwordArgs}`);
         } else if (selectedPasswordInput === "Basic") {
@@ -308,11 +328,13 @@ const Hydra = () => {
                                 />
                             )}
                             {isLoginFile && (
-                                <TextInput
-                                    {...form.getInputProps("loginArgs")}
-                                    label={"File path"}
-                                    placeholder={"eg: /home/kali/Desktop/logins.txt"}
-                                    required
+                                <FilePicker
+                                    fileNames={fileNames}
+                                    setFileNames={setFileNames}
+                                    multiple={false}
+                                    componentName="Hydra"
+                                    labelText="Login File (Can only select files in /home/kali)"
+                                    placeholderText="Click to select file(s)"
                                 />
                             )}
                         </Grid.Col>
@@ -338,19 +360,13 @@ const Hydra = () => {
                                 />
                             )}
                             {isPasswordFile && (
-                                <TextInput
-                                    {...form.getInputProps("passwordArgs")}
-                                    label={"File path"}
-                                    placeholder={"eg: /home/kali/Desktop/pwd.txt"}
-                                    required
-                                />
-                            )}
-                            {isPasswordSet && (
-                                <TextInput
-                                    {...form.getInputProps("passwordArgs")}
-                                    label={"Character Set"}
-                                    placeholder={"eg: 1:5:Aa1"}
-                                    required
+                                <FilePicker
+                                    fileNames={fileNames}
+                                    setFileNames={setFileNames}
+                                    multiple={false}
+                                    componentName="Hydra"
+                                    labelText="Password File (Can only select files in /home/kali)"
+                                    placeholderText="Click to select file(s)"
                                 />
                             )}
                             {isPasswordBasic && (

--- a/src/components/JohnTheRipper/JohnTheRipper.tsx
+++ b/src/components/JohnTheRipper/JohnTheRipper.tsx
@@ -9,6 +9,7 @@ import { RenderComponent } from "../UserGuide/UserGuide";
 import InstallationModal from "../InstallationModal/InstallationModal";
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
+import { FilePicker } from "../FileHandler/FilePicker";
 
 /**
  * Represents the form values for the JohnTheRipper component.
@@ -21,6 +22,16 @@ interface FormValuesType {
     wordList: string;
     incrementOrder: string;
 }
+
+//Deals with the generatedfilepath unique identifier that is added at the end of a file created by the FilePicker component
+const cleanFileName = (filePath: string): string => {
+    // Split the file name by the underscore (_) and keep the first part (before the timestamp/ID)
+    const parts = filePath.split("_");
+
+    // Keep only the base file name (before the timestamp and unique identifier)
+    const baseFileName = parts[0];
+    return baseFileName;
+};
 
 /**
  * The JohnTheRipper component.
@@ -39,6 +50,7 @@ const JohnTheRipper = () => {
     const [selectedFileTypeOption, setSelectedFileTypeOption] = useState(""); // State variable to store the selected file type.
     const [selectedModeOption, setSelectedModeOption] = useState(""); // State variable to store the selected crack mode.
     const [selectedIncrementOption, setSelectedIncrementOption] = useState(""); // State variable to store the selected increment order.
+    const [fileNames, setFileNames] = useState<string[]>([]); // State variable to store the file names.
 
     // Component constants
     const modeRequiringWordList = ["dictionary"]; // Crack modes that require a wordlist
@@ -170,9 +182,14 @@ const JohnTheRipper = () => {
         // Disallow saving until the tool's execution is complete
         setAllowSave(false);
 
+        const fileToProcess = fileNames[0]; // Assuming only one file is selected.
+        const cleanName = cleanFileName(fileToProcess);
+        const baseFilePath = "/home/kali";
+        const filePathToUse = `${baseFilePath}/${cleanName}`;
+
         // If hash is stored in a text file
         if (values.fileType === "raw") {
-            const args = [values.filePath];
+            const args = [filePathToUse];
             values.hash ? args.push(`--format=${values.hash}`) : undefined;
 
             selectedModeOption === "dictionary"
@@ -200,7 +217,7 @@ const JohnTheRipper = () => {
                 });
         } else {
             // If hash is stored in a zip/rar file
-            const argsExtract = [values.filePath];
+            const argsExtract = [filePathToUse];
             const argsCrack = [`/tmp/hash.txt`];
 
             // Extract password hash from zip/rar files
@@ -282,7 +299,14 @@ const JohnTheRipper = () => {
             <form onSubmit={form.onSubmit((values) => onSubmit({ ...values, fileType: selectedFileTypeOption }))}>
                 {LoadingOverlayAndCancelButton(loading, pid)}
                 <Stack>
-                    <TextInput label={"Filepath"} required {...form.getInputProps("filePath")} />
+                    <FilePicker
+                        fileNames={fileNames}
+                        setFileNames={setFileNames}
+                        multiple={false}
+                        componentName="JohnTheRipper"
+                        labelText="File (Can only select files in /home/kali)"
+                        placeholderText="Click to select file(s)"
+                    />
                     <TextInput label={"Hash Type (if known)"} {...form.getInputProps("hash")} />
                     <NativeSelect
                         value={selectedModeOption}

--- a/src/components/Netcat/Netcat.tsx
+++ b/src/components/Netcat/Netcat.tsx
@@ -8,6 +8,7 @@ import { LoadingOverlayAndCancelButtonPkexec } from "../OverlayAndCancelButton/O
 import InstallationModal from "../InstallationModal/InstallationModal";
 import { RenderComponent } from "../UserGuide/UserGuide";
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
+import { FilePicker } from "../FileHandler/FilePicker";
 
 /**
  * Represents the form values for the Netcat component.
@@ -22,12 +23,22 @@ interface FormValuesType {
     filePath: string;
 }
 
+//Deals with the generatedfilepath unique identifier that is added at the end of a file
+const cleanFileName = (filePath: string): string => {
+    // Split the file name by the underscore (_) and keep the first part (before the timestamp/ID)
+    const parts = filePath.split("_");
+
+    // Keep only the base file name (before the timestamp and unique identifier)
+    const baseFileName = parts[0];
+    return baseFileName;
+};
+
 //Netcat Options Configuration
 const netcatOptions = ["Listen", "Connect", "Port Scan", "Send File", "Receive File", "Website Port Scan"];
 
 /**
  * The Netcat component.
- * @returns The Netcat component.
+ * @returns The Netcat component.import path from 'path'
  */
 //Tool name must be capital or jsx will cry out errors :P
 const NetcatTool = () => {
@@ -42,6 +53,7 @@ const NetcatTool = () => {
     const [checkedVerboseMode, setCheckedVerboseMode] = useState(false); // State variable to indicate whether the verbose mode is enabled.
     const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state of the modal.
     const [opened, setOpened] = useState(!isCommandAvailable); // State variable that indicates if the modal is opened.
+    const [fileNames, setFileNames] = useState<string[]>([]); // State variable to store the file names.
     // Component Constants.
     const title = "Netcat"; // Title of the component.
     const description =
@@ -146,7 +158,7 @@ const NetcatTool = () => {
 
         //Switch case
         switch (values.netcatOptions) {
-            case "Listen": //Sets up nc listener, nc syntax: nc -lvp <port number>
+            case "Listen": //Sets up nc listener, nc synimport { FilePicker } from "../FileHandler/FilePicker";ax: nc -lvp <port number>
                 args = [`-l${verboseFlag}p`];
                 args.push(values.portNumber);
 
@@ -193,11 +205,10 @@ const NetcatTool = () => {
                 break;
 
             case "Port Scan": //nc syntax: nc -zv <ip address/hostname> <port range>
-                //addition of -n will not perform any dns or name lookups.
+                //addition of -n will not perform any dns or name lookups.import path from 'path'
 
                 args = [`-z${verboseFlag}n`];
                 args.push(`${values.ipAddress}`);
-
                 if (values.portNumber.includes("-")) {
                     //checks for port range specifed by the inclusion of "-"
                     const [portStart, portEnd] = values.portNumber.split("-").map(Number); //Splits range by "-", assigns two consts with the split port numbers
@@ -227,15 +238,25 @@ const NetcatTool = () => {
 
             case "Send File": //Sends file from attacker to victim, syntax: nc -v -w <timeout seconds> <IP address> <port number> < <file path>
                 //File to send can be located anywhere, as long as file path is correctly specified
+
+                const baseFilePath = "/home/kali";
+                const fileToSend = fileNames[0];
+                const cleanName = cleanFileName(fileToSend);
+
+                //Concatenate the base file path with the cleaned file name
+                const dataUploadPath = `${baseFilePath}/${cleanName}`;
+
+                //Output the final clean file path for debugging
+                args.push("-l", dataUploadPath);
+
                 try {
-                    let command = `nc${verboseFlagWithSpaceAndDash} -w 10 ${values.ipAddress} ${values.portNumber} < ${values.filePath}`;
-                    let output = await CommandHelper.runCommand("bash", ["-c", command]); //when using '<', command needs to be run via bash shell to recognise that '<' is an input direction
+                    let command = `nc${verboseFlagWithSpaceAndDash} -w 10 ${values.ipAddress} ${values.portNumber} < ${dataUploadPath}`;
+                    let output = await CommandHelper.runCommand("bash", ["-c", command]);
                     setOutput(output);
                 } catch (e: any) {
                     setOutput(e);
                 }
                 break;
-
             case "Receive File": //Receives file from victim to attacker, syntax: nc -lvp <port number> > <file path and file name>
                 //Files can be recieved in any directory
                 try {
@@ -345,7 +366,14 @@ const NetcatTool = () => {
                         <>
                             <TextInput label={"IP address"} required {...form.getInputProps("ipAddress")} />
                             <TextInput label={"Port number"} required {...form.getInputProps("portNumber")} />
-                            <TextInput label={"File path"} required {...form.getInputProps("filePath")} />
+                            <FilePicker
+                                fileNames={fileNames}
+                                setFileNames={setFileNames}
+                                multiple={false}
+                                componentName="Netcat"
+                                labelText="File"
+                                placeholderText="Click to select file(s)"
+                            />
                         </>
                     )}
                     {selectedScanOption === "Receive File" && (

--- a/src/components/Netcat/Netcat.tsx
+++ b/src/components/Netcat/Netcat.tsx
@@ -38,7 +38,7 @@ const netcatOptions = ["Listen", "Connect", "Port Scan", "Send File", "Receive F
 
 /**
  * The Netcat component.
- * @returns The Netcat component.import path from 'path'
+ * @returns The Netcat component.
  */
 //Tool name must be capital or jsx will cry out errors :P
 const NetcatTool = () => {

--- a/src/components/Netcat/Netcat.tsx
+++ b/src/components/Netcat/Netcat.tsx
@@ -158,7 +158,7 @@ const NetcatTool = () => {
 
         //Switch case
         switch (values.netcatOptions) {
-            case "Listen": //Sets up nc listener, nc synimport { FilePicker } from "../FileHandler/FilePicker";ax: nc -lvp <port number>
+            case "Listen": //Sets up nc listener, nc syntax: nc -lvp <port number>
                 args = [`-l${verboseFlag}p`];
                 args.push(values.portNumber);
 
@@ -205,7 +205,7 @@ const NetcatTool = () => {
                 break;
 
             case "Port Scan": //nc syntax: nc -zv <ip address/hostname> <port range>
-                //addition of -n will not perform any dns or name lookups.import path from 'path'
+                //addition of -n will not perform any dns or name lookups.
 
                 args = [`-z${verboseFlag}n`];
                 args.push(`${values.ipAddress}`);

--- a/src/components/RTsort/RTsort.tsx
+++ b/src/components/RTsort/RTsort.tsx
@@ -8,6 +8,7 @@ import { RenderComponent } from "../UserGuide/UserGuide";
 import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
 import InstallationModal from "../InstallationModal/InstallationModal";
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
+import { FilePicker } from "../FileHandler/FilePicker";
 
 /**
  * Represents the form values for the RTsort component.
@@ -15,6 +16,16 @@ import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 interface FormValuesType {
     path: string;
 }
+
+//Deals with the generatedfilepath unique identifier that is added at the end of a file
+const cleanFileName = (filePath: string): string => {
+    // Split the file name by the underscore (_) and keep the first part (before the timestamp/ID)
+    const parts = filePath.split("_");
+
+    // Keep only the base file name (before the timestamp and unique identifier)
+    const baseFileName = parts[0];
+    return baseFileName;
+};
 
 // Function for implementing RTSort as GUI component
 const RTSort = () => {
@@ -27,6 +38,7 @@ const RTSort = () => {
     const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state of the modal.
     const [isCommandAvailable, setIsCommandAvailable] = useState(false); // State variable to check if the command is available.
     const [opened, setOpened] = useState(!isCommandAvailable); // State variable that indicates if the modal is opened.
+    const [fileNames, setFileNames] = useState<string[]>([]); // State variable to store the file names.
 
     // Component Constants.
     const title = "Rainbow Table Sort"; // Title of the component.
@@ -119,6 +131,14 @@ const RTSort = () => {
         setLoading(true);
         // Disallow saving until the tool's execution is complete
         setAllowSave(false);
+
+        const baseFilePath = "/home/kali";
+        const fileToSend = fileNames[0];
+        const cleanName = cleanFileName(fileToSend);
+
+        // Concatenate the base file path with the cleaned file name
+        const dataUploadPath = `${baseFilePath}/${cleanName}`;
+
         // Construct arguments for the RTsort command based on form input
         const args = [values.path];
         const filteredArgs = args.filter((arg) => arg !== ""); // Variable to store non empty string as argument
@@ -178,11 +198,13 @@ const RTSort = () => {
             <form onSubmit={form.onSubmit(onSubmit)}>
                 {LoadingOverlayAndCancelButton(loading, pid)}
                 <Stack>
-                    <TextInput
-                        label={"Path"}
-                        required
-                        placeholder="/home/user/rainbowcrack/tables/ntlm_loweralpha-numeric#1-9_0_1000x1000_0.rt"
-                        {...form.getInputProps("path")}
+                    <FilePicker
+                        fileNames={fileNames}
+                        setFileNames={setFileNames}
+                        multiple={false}
+                        componentName="RTsort"
+                        labelText="Select File (Can only select files in /home/kali)"
+                        placeholderText="Click to select file(s)"
                     />
                     <Button type={"submit"}>Start Sort</Button>
                     {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}


### PR DESCRIPTION
This pull request integrates the FilePicker component into Netcat, specifically enhancing the 'Send File' functionality by allowing users to easily locate and select the desired file.  It should however be noted that this will only work if the file is located in /home/kali. The component has not been implemented for the 'Receive File' function, as it would cause that functionality to break.