### PR TITLE
Fixing invalid Arguments Passed by Slowhttptest GUI

### DIFF
--- a/src/components/slowhttptest/slowhttptest.tsx
+++ b/src/components/slowhttptest/slowhttptest.tsx
@@ -130,9 +130,8 @@ function SlowHttpTest() {
         setLoading(true); // Enable the Loading Overlay
 
         const args = [`-u`, `${values.url}`];
-        args.push(`--timeout`, `${values.timeout}`);
-        args.push(`--requests`, `${values.requests}`);
-        args.push(`--no-prompt`);
+        args.push(`-i`, `${values.timeout}`);
+        args.push(`-r`, `${values.requests}`);
 
         CommandHelper.runCommandGetPidAndOutput("slowhttptest", args, handleProcessData, handleProcessTermination)
             .then(({ pid, output }) => {


### PR DESCRIPTION
Fixing #1098 

Before fix:
<img width="1278" alt="Screenshot 2024-12-20 at 11 49 54 pm" src="https://github.com/user-attachments/assets/e8657c8c-57a9-494f-9a3a-4684c64d971e" />

After fix:
<img width="1267" alt="Screenshot 2024-12-20 at 11 53 34 pm" src="https://github.com/user-attachments/assets/cf7f2434-a5f2-4e9a-bdcd-f28028a44260" />
