### PR TITLE
Setup_ddt.sh update: Check Debian security and repository already added in sources.list 

### DIFF
--- a/install-update-media/setup_ddt.sh
+++ b/install-update-media/setup_ddt.sh
@@ -2,8 +2,10 @@
 
 set -e
 
-# Add Debian security updates and main repository to sources.list
-sudo sh -c 'echo "deb http://security.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list && echo "deb http://ftp.au.debian.org/debian buster main" >> /etc/apt/sources.list'
+# Add Debian security updates and main repository to sources.list if not already added
+# NOTE: ^ indicates string pattern starts on a new line. Avoids matching with hash version, e.g.: #deb
+grep -q "^deb http://security.debian.org/debian-security buster/updates main" "/etc/apt/sources.list" && echo 'Already added Debian security to sources.list.' || sudo sh -c 'echo "deb http://security.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list'
+grep -q "^deb http://ftp.au.debian.org/debian buster main" "/etc/apt/sources.list" && echo 'Already added Debian to sources.list.' || sudo sh -c 'echo "deb http://ftp.au.debian.org/debian buster main" >> /etc/apt/sources.list'
 
 # Preconfigure debconf to restart services during upgrades without asking
 echo libc6 libraries/restart-without-asking boolean true | sudo debconf-set-selections


### PR DESCRIPTION
Updates setup_ddt.sh file in GitHub repo 
- Currently debian security & repository are added to /etc/apt/sources.list every time curl command or ./setup_ddt.sh is run
- This updates setup file to check if the source is already added 
- Does not add again if this is true (separate check for each source)
- Avoids possible issue with matching #deb http://... file with ^ character
- Prints validation to console for user