### PR TITLE
fix bug#1151 100% CPU while executing Amass tool

### DIFF
--- a/src/components/OverlayAndCancelButton/OverlayAndCancelButton.tsx
+++ b/src/components/OverlayAndCancelButton/OverlayAndCancelButton.tsx
@@ -18,7 +18,7 @@ export function LoadingOverlayAndCancelButton(loading: boolean, pid: string) {
 
     return (
         <>
-            <LoadingOverlay visible={loading} overlayBlur={3} style={{ zIndex: 1000, position: "fixed" }} />
+            <LoadingOverlay visible={false} overlayBlur={3} style={{ zIndex: 1000, position: "fixed" }} />
             {loading && (
                 <Modal
                     opened={loading}
@@ -85,7 +85,7 @@ export function LoadingOverlayAndCancelButtonPkexec(
     //Returns a loadingoverlay function to handle process termination for pkexec
     return (
         <>
-            <LoadingOverlay visible={loading} overlayBlur={3} style={{ zIndex: 1000, position: "fixed" }} />
+            <LoadingOverlay visible={false} overlayBlur={3} style={{ zIndex: 1000, position: "fixed" }} />
             {loading && (
                 <Modal
                     opened={loading}


### PR DESCRIPTION
-fixed issue with Amass high CPU (this has been reported as an issue by several team members testing different tools).
-located issue in cancel button overlay
 
-changed line 21 and 88 to make the loading overlay not be rendered by setting visible to false from

"<LoadingOverlay visible={loading} overlayBlur={3} style={{ zIndex: 1000, position: "fixed" }} />"

to 

" <LoadingOverlay visible={false} overlayBlur={3} style={{ zIndex: 1000, position: "fixed" }} />"

this was being rendered continuously in the background form what i could tell.

-tested and fixed.

NOTE:The cancel button overlay is used across many DDT tools, and while my testing showed no obvious issues, unintended consequences are possible. This change only affects the visibility of the loading overlay and not the whole functionality of the cancel button overlay or the loading overlay, so i would assume it should not be a problem.
