### PR TITLE
change package manager to yarn to match project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-    # Enable version updates for yarn package manager 
+    # Enable version updates for yarn package manager
     - package-ecosystem: "yarn" # See documentation for other possible values
       # Look for 'package.json' and 'lock' files in the 'root' directory
       directory: "/" # Location of package manifests

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,15 @@
 
 version: 2
 updates:
-    # Enable version updates for npm
-    - package-ecosystem: "npm" # See documentation for other possible values
+    # Enable version updates for yarn package manager 
+    - package-ecosystem: "yarn" # See documentation for other possible values
       # Look for 'package.json' and 'lock' files in the 'root' directory
       directory: "/" # Location of package manifests
       # Check the npm registry for updates once/week
       schedule:
           interval: "weekly"
           day: "sunday"
-      # increase the version requirements for npm dependencies
+      # increase the version requirements for yarn dependencies
       # only when required
       versioning-strategy: "increase-if-necessary"
-      open-pull-requests-limit: 10
+      open-pull-requests-limit: 5


### PR DESCRIPTION
-change package manager to yarn, as npm will update package-lock when we want to update yarn-lock file
-reduce PRs to 5

- Realized this isn't actually running currently. Will enable later after review 