### PR TITLE
Bug #1247 Loading Screen in Arp Spoof tool

### DIFF
--- a/src/components/AirbaseNG/AirbaseNG.tsx
+++ b/src/components/AirbaseNG/AirbaseNG.tsx
@@ -210,7 +210,7 @@ const AirbaseNG = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
 
                     {/* Advanced Mode Switch */}
                     <Tooltip label="Enable advanced settings">

--- a/src/components/ArpSpoof/ArpSpoof.tsx
+++ b/src/components/ArpSpoof/ArpSpoof.tsx
@@ -152,7 +152,7 @@ const ARPSpoofing = () => {
         const argsTarget = [`-t`, values.ipTarget, values.ipGateway];
 
         CommandHelper;
-        // Execute the arpspoof command for the Gateway using helper method 
+        // Execute the arpspoof command for the Gateway using helper method
         CommandHelper.runCommandWithPkexec("arpspoof", argsGateway, handleProcessData, handleProcessTermination)
             .then(({ output, pid }) => {
                 setOutput(output);
@@ -164,19 +164,18 @@ const ARPSpoofing = () => {
                 // Deactivate loading state
                 setLoading(false);
             });
-            // Execute the arpspoof command for the Target using helper method 
-            CommandHelper.runCommandWithPkexec("arpspoof", argsTarget, handleProcessData, handleProcessTermination)
-                .then(({ output, pid }) => {
-                    setOutput(output);
-                    setPidTarget(pid);
-                })
-                .catch((error) => {
-                    // Display any errors encountered during command execution
-                    setOutput(`Error: ${error.message}`);
-                    // Deactivate loading state
-                    setLoading(false);
-                });
-        
+        // Execute the arpspoof command for the Target using helper method
+        CommandHelper.runCommandWithPkexec("arpspoof", argsTarget, handleProcessData, handleProcessTermination)
+            .then(({ output, pid }) => {
+                setOutput(output);
+                setPidTarget(pid);
+            })
+            .catch((error) => {
+                // Display any errors encountered during command execution
+                setOutput(`Error: ${error.message}`);
+                // Deactivate loading state
+                setLoading(false);
+            });
     };
 
     return (
@@ -198,7 +197,13 @@ const ARPSpoofing = () => {
                 )}
                 <form onSubmit={form.onSubmit((values) => onSubmit(values))}>
                     <Stack>
-                        {LoadingOverlayAndCancelButtonPkexec(loading,pidGateway, pidTarget,handleProcessData,handleProcessTermination)}
+                        {LoadingOverlayAndCancelButtonPkexec(
+                            loading,
+                            pidGateway,
+                            pidTarget,
+                            handleProcessData,
+                            handleProcessTermination
+                        )}
                         <TextInput label={"Target one IP address"} required {...form.getInputProps("ipGateway")} />
                         <TextInput label={"Target two IP address"} required {...form.getInputProps("ipTarget")} />
                         <Button type={"submit"}>Start Spoof</Button>

--- a/src/components/ArpSpoof/ArpSpoof.tsx
+++ b/src/components/ArpSpoof/ArpSpoof.tsx
@@ -100,7 +100,7 @@ const ARPSpoofing = () => {
             if (code === 0) {
                 handleProcessData("\nProcess completed successfully.");
                 // If the process was terminated due to a signal, display the signal code.
-            } else if (signal === 15) {
+            } else if (signal === 2) {
                 handleProcessData("\nProcess was manually terminated.");
                 // If the process was terminated with an error, display the exit code and signal code.
             } else {
@@ -151,25 +151,32 @@ const ARPSpoofing = () => {
         const argsGateway = [`-t`, values.ipGateway, values.ipTarget];
         const argsTarget = [`-t`, values.ipTarget, values.ipGateway];
 
-        // Execute arpspoof command for the gateway
-        const result_gateway = await CommandHelper.runCommandWithPkexec(
-            "arpspoof",
-            argsGateway,
-            handleProcessData,
-            handleProcessTermination
-        );
-        setPidGateway(result_gateway.pid);
-
-        // Execute arpspoof command for the target
-        const result_target = await CommandHelper.runCommandWithPkexec(
-            "arpspoof",
-            argsTarget,
-            handleProcessData,
-            handleProcessTermination
-        );
-        setPidTarget(result_target.pid);
-
-        setLoading(false);
+        CommandHelper;
+        // Execute the arpspoof command for the Gateway using helper method 
+        CommandHelper.runCommandWithPkexec("arpspoof", argsGateway, handleProcessData, handleProcessTermination)
+            .then(({ output, pid }) => {
+                setOutput(output);
+                setPidGateway(pid);
+            })
+            .catch((error) => {
+                // Display any errors encountered during command execution
+                setOutput(`Error: ${error.message}`);
+                // Deactivate loading state
+                setLoading(false);
+            });
+            // Execute the arpspoof command for the Target using helper method 
+            CommandHelper.runCommandWithPkexec("arpspoof", argsTarget, handleProcessData, handleProcessTermination)
+                .then(({ output, pid }) => {
+                    setOutput(output);
+                    setPidTarget(pid);
+                })
+                .catch((error) => {
+                    // Display any errors encountered during command execution
+                    setOutput(`Error: ${error.message}`);
+                    // Deactivate loading state
+                    setLoading(false);
+                });
+        
     };
 
     return (
@@ -191,18 +198,7 @@ const ARPSpoofing = () => {
                 )}
                 <form onSubmit={form.onSubmit((values) => onSubmit(values))}>
                     <Stack>
-                        {LoadingOverlayAndCancelButtonPkexec(
-                            loading,
-                            pidGateway,
-                            handleProcessData,
-                            handleProcessTermination
-                        )}
-                        {LoadingOverlayAndCancelButtonPkexec(
-                            loading,
-                            pidTarget,
-                            handleProcessData,
-                            handleProcessTermination
-                        )}
+                        {LoadingOverlayAndCancelButtonPkexec(loading,pidGateway, pidTarget,handleProcessData,handleProcessTermination)}
                         <TextInput label={"Target one IP address"} required {...form.getInputProps("ipGateway")} />
                         <TextInput label={"Target two IP address"} required {...form.getInputProps("ipTarget")} />
                         <Button type={"submit"}>Start Spoof</Button>

--- a/src/components/Arping/Arping.tsx
+++ b/src/components/Arping/Arping.tsx
@@ -196,7 +196,7 @@ const Arping = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <TextInput
                         label="Target IP Address"
                         required

--- a/src/components/Crunch/Crunch.tsx
+++ b/src/components/Crunch/Crunch.tsx
@@ -188,7 +188,7 @@ const Crunch = () => {
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <LoadingOverlay visible={loading} />
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <LoadingOverlay visible={loading} />
                     {/* {UserGuide(title, description_userguide)} */}
                     <TextInput

--- a/src/components/Fping/Fping.tsx
+++ b/src/components/Fping/Fping.tsx
@@ -299,7 +299,7 @@ function Fping() {
             )}
             <form onSubmit={form.onSubmit((values) => onSubmit(values))}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <Switch
                         label="Target File"
                         checked={checkedFilePath}

--- a/src/components/GobusterTool/Gobuster.tsx
+++ b/src/components/GobusterTool/Gobuster.tsx
@@ -169,7 +169,7 @@ const GoBusterTool = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <TextInput label={"Target URL"} required {...form.getInputProps("url")} />
                     <TextInput label={"Wordlist File"} required {...form.getInputProps("wordlist")} />
                     <Button type={"submit"}>Start {title}</Button>

--- a/src/components/Goldeneye/Goldeneye.tsx
+++ b/src/components/Goldeneye/Goldeneye.tsx
@@ -205,7 +205,7 @@ const Goldeneye = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <TextInput
                         label={"URL of the target"}
                         placeholder={"Example: https://www.google.com"}

--- a/src/components/Hashcat/Hashcat.tsx
+++ b/src/components/Hashcat/Hashcat.tsx
@@ -277,7 +277,7 @@ const Hashcat = () => {
                 </Grid>
 
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <NumberInput label="Hash Algorithm Code" {...form.getInputProps("hashAlgorithmCode")} required />
                     {!isFile && <TextInput label="Hash Value" {...form.getInputProps("hashValue")} required />}
                     {isFile && <TextInput label="Hash File Path" {...form.getInputProps("hashFilePath")} required />}

--- a/src/components/Hping3/Hping3.tsx
+++ b/src/components/Hping3/Hping3.tsx
@@ -219,7 +219,7 @@ const Hping3 = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <NativeSelect
                         value={selectedOption}
                         onChange={(e) => setSelectedOption(e.target.value)}

--- a/src/components/Masscan/Masscan.tsx
+++ b/src/components/Masscan/Masscan.tsx
@@ -225,7 +225,7 @@ const Masscan = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <TextInput
                         label="IP Address/Range/Subnet"
                         required

--- a/src/components/NbtscanTool/NbtscanTool.tsx
+++ b/src/components/NbtscanTool/NbtscanTool.tsx
@@ -98,7 +98,7 @@ const NbtscanTool = () => {
         ({ code, signal }: { code: number; signal: number }) => {
             if (code === 0) {
                 handleProcessData("\nProcess completed successfully.");
-            } else if (signal === 15) {
+            } else if (signal === 2) {
                 handleProcessData("\nProcess was manually terminated.");
             } else {
                 handleProcessData(`\nProcess terminated with exit code: ${code} and signal code: ${signal}`);
@@ -202,7 +202,7 @@ const NbtscanTool = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <Switch
                         size="md"
                         label="Advanced Mode"

--- a/src/components/Netcat/Netcat.tsx
+++ b/src/components/Netcat/Netcat.tsx
@@ -254,7 +254,7 @@ const NetcatTool = () => {
             )}
             <form onSubmit={form.onSubmit((values) => onSubmit({ ...values, netcatOptions: selectedScanOption }))}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid,"", handleProcessData, handleProcessTermination)}
                     <Checkbox
                         label={"Verbose Mode"}
                         checked={checkedVerboseMode}

--- a/src/components/Netcat/Netcat.tsx
+++ b/src/components/Netcat/Netcat.tsx
@@ -254,7 +254,7 @@ const NetcatTool = () => {
             )}
             <form onSubmit={form.onSubmit((values) => onSubmit({ ...values, netcatOptions: selectedScanOption }))}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid,"", handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <Checkbox
                         label={"Verbose Mode"}
                         checked={checkedVerboseMode}

--- a/src/components/OverlayAndCancelButton/OverlayAndCancelButton.tsx
+++ b/src/components/OverlayAndCancelButton/OverlayAndCancelButton.tsx
@@ -1,5 +1,7 @@
 import { LoadingOverlay, Button, Modal } from "@mantine/core";
 import { CommandHelper } from "../../utils/CommandHelper";
+import { Command } from "@tauri-apps/api/shell";
+
 
 /**
  * Overlay to successfully terminate processes for tools not requiring pkexec
@@ -59,9 +61,14 @@ export function LoadingOverlayAndCancelButton(loading: boolean, pid: string) {
  * @throws If there is an error during cancel process or process ID fails to be acquired
  * @returns A Loading Overlay with cancel button
  */
+
 export function LoadingOverlayAndCancelButtonPkexec(
     loading: boolean,
     pid: string,
+    pid2: string = "", //This argument is optional when calling this function as a default value is defined here. Pid2 is used to allow tools 
+    // that create multiple instances such as ArpSpoof to be sucessfully canceled. If you do not include an argument for pid2 when you call this 
+    // function, you will get a warning, but the function will still work. To avoid getting a warning, simply include emtpy quotation marks in pid2's place. Example:
+    // {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)} 
     onData: (data: string) => void,
     onTermination: ({ code, signal }: { code: number; signal: number }) => void
 ) {
@@ -72,7 +79,12 @@ export function LoadingOverlayAndCancelButtonPkexec(
             if (pid !== null) {
                 const args = [`-2`, pid];
                 CommandHelper.runCommand("kill", args);
-            } else {
+            } 
+            if (pid2 !== null){
+                const args = ['-2', pid2];
+                CommandHelper.runCommand("kill", args);
+            }
+            else {
                 //Throws error if failed to get process ID for termination
                 throw new Error("Error: Failed to get process ID ");
             }

--- a/src/components/OverlayAndCancelButton/OverlayAndCancelButton.tsx
+++ b/src/components/OverlayAndCancelButton/OverlayAndCancelButton.tsx
@@ -2,7 +2,6 @@ import { LoadingOverlay, Button, Modal } from "@mantine/core";
 import { CommandHelper } from "../../utils/CommandHelper";
 import { Command } from "@tauri-apps/api/shell";
 
-
 /**
  * Overlay to successfully terminate processes for tools not requiring pkexec
  * @param loading - An object containing information about the process termination.
@@ -65,10 +64,10 @@ export function LoadingOverlayAndCancelButton(loading: boolean, pid: string) {
 export function LoadingOverlayAndCancelButtonPkexec(
     loading: boolean,
     pid: string,
-    pid2: string = "", //This argument is optional when calling this function as a default value is defined here. Pid2 is used to allow tools 
-    // that create multiple instances such as ArpSpoof to be sucessfully canceled. If you do not include an argument for pid2 when you call this 
+    pid2: string = "", //This argument is optional when calling this function as a default value is defined here. Pid2 is used to allow tools
+    // that create multiple instances such as ArpSpoof to be sucessfully canceled. If you do not include an argument for pid2 when you call this
     // function, you will get a warning, but the function will still work. To avoid getting a warning, simply include emtpy quotation marks in pid2's place. Example:
-    // {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)} 
+    // {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
     onData: (data: string) => void,
     onTermination: ({ code, signal }: { code: number; signal: number }) => void
 ) {
@@ -79,12 +78,11 @@ export function LoadingOverlayAndCancelButtonPkexec(
             if (pid !== null) {
                 const args = [`-2`, pid];
                 CommandHelper.runCommand("kill", args);
-            } 
-            if (pid2 !== null){
-                const args = ['-2', pid2];
-                CommandHelper.runCommand("kill", args);
             }
-            else {
+            if (pid2 !== null) {
+                const args = ["-2", pid2];
+                CommandHelper.runCommand("kill", args);
+            } else {
                 //Throws error if failed to get process ID for termination
                 throw new Error("Error: Failed to get process ID ");
             }

--- a/src/components/Photon/photon.tsx
+++ b/src/components/Photon/photon.tsx
@@ -178,7 +178,7 @@ const Photon = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <TextInput
                         label={"URL of the target"}
                         placeholder={"Example: https://example.com"}

--- a/src/components/SearchSploit/SearchSploit.tsx
+++ b/src/components/SearchSploit/SearchSploit.tsx
@@ -193,7 +193,7 @@ const SearchSploit = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleCancel, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleCancel, handleProcessTermination)}
                     <TextInput label={"Search Term"} {...form.getInputProps("searchTerm")} />
                     <NativeSelect
                         {...form.getInputProps("searchOption")}

--- a/src/components/tiger/tiger.tsx
+++ b/src/components/tiger/tiger.tsx
@@ -125,7 +125,7 @@ const Tiger = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <TextInput
                         label="Report File"
                         required

--- a/src/components/wifite/wifite.tsx
+++ b/src/components/wifite/wifite.tsx
@@ -125,7 +125,7 @@ const Wifite = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <TextInput
                         label="Target Network (BSSID/ESSID)"
                         required


### PR DESCRIPTION
Fixed code for Arp Spoof tool, and added extra functionality to the pkexec cancel button allowing it to accept a second PID to kill. This argument has been identified in the code for the cancel button and has been assigned a default value. When the Pkexec cancel button is called, a warning does appear if the second PID isn't defined, however the cancel button still works as expected with this warning. I have gone through and added an empty argument to the tools that do call this function to avoid any warnings. The button's function remains unchanged for tools that create a single PID and now also works for tasks that create 2. I have found even more bugs within the tools; aircrack ng, gobuster, netcat, photon and sql ninja so I will add these as their own git issues and fix them in separate pull requests