### PR TITLE
Bug 1268 fix

### DIFF
--- a/src/components/GobusterTool/Gobuster.tsx
+++ b/src/components/GobusterTool/Gobuster.tsx
@@ -6,7 +6,7 @@ import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
 import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile";
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 import { RenderComponent } from "../UserGuide/UserGuide";
-import { LoadingOverlayAndCancelButtonPkexec } from "../OverlayAndCancelButton/OverlayAndCancelButton";
+import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
 import InstallationModal from "../InstallationModal/InstallationModal";
 
 const title = "GoBuster Directory and File Brute-Forcing Tool";
@@ -126,8 +126,6 @@ const GoBusterTool = () => {
         } catch (e: any) {
             setOutput(e.message);
         }
-
-        setLoading(false);
     };
 
     /**
@@ -169,7 +167,7 @@ const GoBusterTool = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
+                    {LoadingOverlayAndCancelButton(loading, pid)}
                     <TextInput label={"Target URL"} required {...form.getInputProps("url")} />
                     <TextInput label={"Wordlist File"} required {...form.getInputProps("wordlist")} />
                     <Button type={"submit"}>Start {title}</Button>


### PR DESCRIPTION
On investigating what was causing this issue, I found that setLoading(False) was called at the end of the onSubmit async. This basically meant that when the user started the tool the loading state was set to false, rather then allowing the tool finishing or the use of the cancel button to set the loading state to false, leading to the loading screen not being rendered at all. When I fixed this error, I found that the output in the console when terminating the process using the cancel button, the output was incorrect and read that the process had successfully completed. I discovered that this tool was calling the Pkexec cancel button, which was working to cancel the process, but throwing the wrong code. By changing this tool to employ the regular cancel button, the output reads as expected.