### PR TITLE
Bug 1273 fix

### DIFF
--- a/src/components/rtgen/rtgen.tsx
+++ b/src/components/rtgen/rtgen.tsx
@@ -5,7 +5,7 @@ import { CommandHelper } from "../../utils/CommandHelper";
 import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
 import { RenderComponent } from "../UserGuide/UserGuide";
 import InstallationModal from "../InstallationModal/InstallationModal";
-import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
+import { LoadingOverlayAndCancelButtonPkexec } from "../OverlayAndCancelButton/OverlayAndCancelButton";
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 //import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile";
 
@@ -113,7 +113,7 @@ const Rtgen = () => {
             if (code === 0) {
                 handleProcessData("\nProcess completed successfully.");
                 // If the process was terminated due to a signal, display the signal code.
-            } else if (signal === 15) {
+            } else if (signal === 2) {
                 handleProcessData("\nProcess was manually terminated.");
                 // If the process was terminated with an error, display the exit code and signal code.
             } else {
@@ -152,11 +152,11 @@ const Rtgen = () => {
 
         // Execute the Rtgen command via helper method and handle its output or potential errors
         CommandHelper.runCommandWithPkexec("rtgen", args, handleProcessData, handleProcessTermination)
-            .then(({ output }) => {
+            .then(({ output, pid }) => {
                 // Update the output with the results of the command execution.
                 setOutput(output);
-                // Deactivate loading state
-                setLoading(false);
+                // Update the PID to pass to the cancel button
+                setPid(pid);
             })
             .catch((error) => {
                 // Display any errors encountered during command execution
@@ -204,7 +204,7 @@ const Rtgen = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 <Stack>
-                    {LoadingOverlayAndCancelButton(loading, pid)}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <TextInput
                         label="Hash Algorithm"
                         required


### PR DESCRIPTION
The cancel button now renders, as the original code for this tool set the loading state to false when the tool was run, meaning this overwrote the true command found earlier in onSubmit. When I fixed this, the cancel button rendered but was not working. I discovered that during the run command, the Process ID was never passed to the pid variable which is used for the cancel button. This meant the cancel button wasn't able kill the PID as it was passed a null variable. When I fixed this, the cancel button was still not working as expected, and I discovered that this tool was calling the normal cancel button rather than the Pkexec cancel button. Now that it is calling the correct cancel button, I updated the values in the handle process termination section to ensure the correct output in the shell. The cancel button and this tool as a whole are now working as expected.