### PR TITLE
Bug 1274 fix

### DIFF
--- a/src/components/Urlsnarf/Urlsnarf.tsx
+++ b/src/components/Urlsnarf/Urlsnarf.tsx
@@ -146,7 +146,6 @@ const Urlsnarf = () => {
         args.push(`-v`, `${values.versusMode}`);
 
         if (selectedListenerInput === "Interface") {
-            setLoading(false); // TODO - Have loading state only be true while inputting password
             CommandHelper.runCommandWithPkexec("urlsnarf", args, handleProcessData, handleProcessTermination)
                 .then(({ output, pid }) => {
                     // Update the UI with the results from the executed command


### PR DESCRIPTION
This was a very simple fix, everything was implemented correctly, however there was an argument setting the loading state to in one of the run commands meaning the cancel button wouldn't render. When this was removed, I extensively tested the function of the button within the tool and checked the shell output and it is all working as expected. I also ensured to try the packet capture file function by creating my own capture file and the function remains working as expected