### PR TITLE
 Bug fix 1275

### DIFF
--- a/src/components/ArpScan/ArpScan.tsx
+++ b/src/components/ArpScan/ArpScan.tsx
@@ -134,7 +134,7 @@ function ARPScan() {
         const args = [`--localnet`, `-I`, values.interface];
 
         CommandHelper;
-        // Execute the Masscan command via helper method and handle its output or potential errors
+        // Execute the ArpScan command via helper method and handle its output or potential errors
         CommandHelper.runCommandWithPkexec("arp-scan", args, handleProcessData, handleProcessTermination)
             .then(({ output, pid }) => {
                 setOutput(output);

--- a/src/components/ArpScan/ArpScan.tsx
+++ b/src/components/ArpScan/ArpScan.tsx
@@ -4,7 +4,7 @@ import { useForm } from "@mantine/form";
 import { CommandHelper } from "../../utils/CommandHelper";
 import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
 import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile";
-import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
+import { LoadingOverlayAndCancelButtonPkexec } from "../OverlayAndCancelButton/OverlayAndCancelButton";
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 import InstallationModal from "../InstallationModal/InstallationModal";
 import { RenderComponent } from "../UserGuide/UserGuide";
@@ -24,6 +24,7 @@ function ARPScan() {
     // Component State Variables.
     const [loading, setLoading] = useState(false); // State variable to indicate loading state.
     const [output, setOutput] = useState(""); // State variable to store the output of the command execution.
+    const [pid, setPid] = useState(""); // State variable to store the process ID of the command execution.
     const [allowSave, setAllowSave] = useState(false); // State variable to allow saving the output to a file.
     const [hasSaved, setHasSaved] = useState(false); // State variable to indicate if the output has been saved.
     const [isCommandAvailable, setIsCommandAvailable] = useState(false); // State variable to check if the command is available.
@@ -132,19 +133,20 @@ function ARPScan() {
         // Construct the arguments for the ARPScan command.
         const args = [`--localnet`, `-I`, values.interface];
 
-        try {
-            // Execute the ARPScan command using the CommandHelper utility with pkexec.
-            await CommandHelper.runCommandWithPkexec("arp-scan", args, handleProcessData, handleProcessTermination);
-        } catch (error: any) {
-            // If an error occurs during command execution, display the error message.
-            setOutput(`Error: ${error.message}`);
-
-            // Set the loading state to false since the process failed.
-            setLoading(false);
-
-            // Allow saving the output (which includes the error message) to a file.
-            setAllowSave(true);
-        }
+        CommandHelper;
+        // Execute the Masscan command via helper method and handle its output or potential errors
+        CommandHelper.runCommandWithPkexec("arp-scan", args, handleProcessData, handleProcessTermination)
+            .then(({ output, pid }) => {
+                setOutput(output);
+                setPid(pid);
+            })
+            .catch((error) => {
+                // Display any errors encountered during command execution
+                setOutput(`Error: ${error.message}`);
+                // Deactivate loading state
+                setLoading(false);
+            });
+        setAllowSave(true);
     };
 
     /**
@@ -178,7 +180,7 @@ function ARPScan() {
                 )}
                 <form onSubmit={form.onSubmit(onSubmit)}>
                     {/* Render the loading overlay and cancel button */}
-                    {LoadingOverlayAndCancelButton(loading, "")}
+                    {LoadingOverlayAndCancelButtonPkexec(loading, pid, "", handleProcessData, handleProcessTermination)}
                     <Stack>
                         <TextInput label={"Network Interface"} required {...form.getInputProps("interface")} />
                         {loading && (


### PR DESCRIPTION
ArpScan wasn't able to be cancelled as the initial code never set the value of the PID, meaning the cancel button wasn't able to kill the process. Infact, this tool never defined a PID variable to be set as the tool's PID.  the variables 'loading' and 'pid' are meant to be passed to the cancel button, however this tool passed "loading, " "' meaning that it was passing a null value to the function. To rectify this, I declared a PID variable, as well as set its value in the run command and passed this variable to the cancel button. On testing, the cancel button was not working as expected so I changed this tool to employ the pkexec cancel button and it is now working as expected.