### PR TITLE
Further bug fixing for UrlSnarf

### DIFF
--- a/src/components/Urlsnarf/Urlsnarf.tsx
+++ b/src/components/Urlsnarf/Urlsnarf.tsx
@@ -35,7 +35,6 @@ const Urlsnarf = () => {
     const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state of the modal.
 
     // Component constants.
-    const listeners = ["Interface", "Packet capture file"]; // List of listener settings.
     const isListenerInterface = selectedListenerInput === "Interface"; // Check if the selected listener input is an interface.
     const isListenerFile = selectedListenerInput === "Packet capture file"; // Check if the selected listener input is a file.
     const title = "Urlsnarf"; // Title of the component.
@@ -151,11 +150,16 @@ const Urlsnarf = () => {
                     // Update the UI with the results from the executed command
                     setOutput(output);
                     setPid(pid);
+                    setTimeout(() => {
+                        setLoading(false);
+                        setAllowSave(true);
+                    }, 77500);
                 })
                 .catch((error) => {
                     // Display any errors encountered during command execution
                     setOutput(error.message);
                     // Deactivate loading state
+                    setLoading(false);
                 });
         } else if (selectedListenerInput === "Packet capture file") {
             CommandHelper.runCommandGetPidAndOutput("urlsnarf", args, handleProcessData, handleProcessTermination)
@@ -212,9 +216,12 @@ const Urlsnarf = () => {
                         value={selectedListenerInput}
                         onChange={(e) => setSelectedListenerInput(e.target.value)}
                         label={"listener settings"}
-                        data={listeners}
+                        data={[
+                            { value: "", label: "Select URL-Snarf Mode", disabled: true },
+                            { value: "Interface", label: "Interface" },
+                            { value: "Packet capture file", label: "Packet Capture File" },
+                        ]}
                         required
-                        placeholder={"Interface or PCAP file"}
                     />
                     {isListenerInterface && (
                         <TextInput


### PR DESCRIPTION
This fix addresses concerns raised about the ability to launch the tool before selecting options, leading to the loading state initiating and not being able to cancel it. I have fixed the drop down list so that the user must select and option, and then fill the required fields before the tool will start. This means the cancel button works to cancel the tool in all instances