### PR TITLE
Fix for Traceroute Failing to accept multiple additional flags issue …

### DIFF
--- a/src/components/Traceroute/Traceroute.tsx
+++ b/src/components/Traceroute/Traceroute.tsx
@@ -133,9 +133,11 @@ const Traceroute = () => {
      * @param {FormValuesType} values - Contains the type of traceroute scan (ICMP, TCP, UDP, custom),
      * the destination hostname, and optional custom traceroute options.
      */
+        
+        // Patched onSubmit handler snippet for "Traceroute custom scan"
     const onSubmit = async (values: FormValuesType) => {
-        setLoading(true); // Activate loading state to indicate ongoing process
-        let args = [""];
+        setLoading(true);
+        let args: string[] = [];
 
         // Switch case to handle different traceroute scan options based on user selection.
         switch (values.traceRouteSwitch) {
@@ -191,25 +193,39 @@ const Traceroute = () => {
                     });
 
                 break;
-            // Traceroute custom scan allows specifying additional options
-            // Syntax: traceroute <options> <hostname>
-            case "Traceroute custom scan":
-                args = [`/usr/share/ddt/Bash-Scripts/Tracerouteshell.sh`];
-                args.push(`${values.traceRouteOptions}`); // Adds custom options to the arguments list.
-                args.push(`${values.hostname}`); // Adds the hostname to the arguments list.
-                CommandHelper.runCommandGetPidAndOutput("bash", args, handleProcessData, handleProcessTermination)
-                    .then(({ pid, output }) => {
-                        setPid(pid);
-                        setOutput(output);
-                        setAllowSave(true);
-                    })
-                    .catch((error: any) => {
-                        setLoading(false);
-                        setOutput(`Error: ${error.message}`);
-                    });
+	   // Traceroute custom scan allows specifying additional options        
+           case "Traceroute custom scan": {
+               args = ["/usr/share/ddt/Bash-Scripts/Tracerouteshell.sh"];
+               // Hostname is always the first argument
+     	       args.push(values.hostname);
 
-                break;
+          // Combine all custom flags into a single string for second argument
+          const rawFlags = values.traceRouteOptions.trim();
+          if (rawFlags.length > 0) {
+            args.push(rawFlags);
+          }
+
+              // Execute Traceroute with all arguments
+              CommandHelper.runCommandGetPidAndOutput(
+                  "bash",
+                  args,
+                  handleProcessData,
+                  handleProcessTermination
+              )
+              .then(({ pid, output }) => {
+                  setPid(pid);
+                  setOutput(output);
+                  setAllowSave(true);
+              })
+              .catch((error: any) => {
+                  setLoading(false);
+                  setOutput(`Error: ${error.message}`);
+              });
+
+            break;
         }
+   
+       }
     };
 
     /**
@@ -246,7 +262,7 @@ const Traceroute = () => {
                 <Stack>
                     {LoadingOverlayAndCancelButton(loading, pid)}
                     <TextInput label={"Hostname/IP address"} {...form.getInputProps("hostname")} />
-                    <TextInput label={"Traceroute custom (optional)"} {...form.getInputProps("tracerouteOptions")} />
+                    <TextInput label={"Traceroute custom (optional)"} {...form.getInputProps("traceRouteOptions")} />
                     <NativeSelect
                         value={selectedScanOption}
                         onChange={(e) => setSelectedTracerouteOption(e.target.value)}

--- a/src/components/Traceroute/Traceroute.tsx
+++ b/src/components/Traceroute/Traceroute.tsx
@@ -133,11 +133,14 @@ const Traceroute = () => {
      * @param {FormValuesType} values - Contains the type of traceroute scan (ICMP, TCP, UDP, custom),
      * the destination hostname, and optional custom traceroute options.
      */
+<<<<<<< HEAD
 
     // Patched onSubmit handler snippet for "Traceroute custom scan"
+=======
+>>>>>>> parent of 65dcab0 (Fix for Traceroute Failing to accept multiple additional flags issue 1217)
     const onSubmit = async (values: FormValuesType) => {
-        setLoading(true);
-        let args: string[] = [];
+        setLoading(true); // Activate loading state to indicate ongoing process
+        let args = [""];
 
         // Switch case to handle different traceroute scan options based on user selection.
         switch (values.traceRouteSwitch) {
@@ -194,6 +197,7 @@ const Traceroute = () => {
 
                 break;
             // Traceroute custom scan allows specifying additional options
+<<<<<<< HEAD
             case "Traceroute custom scan": {
                 args = ["/usr/share/ddt/Bash-Scripts/Tracerouteshell.sh"];
                 // Hostname is always the first argument
@@ -219,6 +223,25 @@ const Traceroute = () => {
 
                 break;
             }
+=======
+            // Syntax: traceroute <options> <hostname>
+            case "Traceroute custom scan":
+                args = [`/usr/share/ddt/Bash-Scripts/Tracerouteshell.sh`];
+                args.push(`${values.traceRouteOptions}`); // Adds custom options to the arguments list.
+                args.push(`${values.hostname}`); // Adds the hostname to the arguments list.
+                CommandHelper.runCommandGetPidAndOutput("bash", args, handleProcessData, handleProcessTermination)
+                    .then(({ pid, output }) => {
+                        setPid(pid);
+                        setOutput(output);
+                        setAllowSave(true);
+                    })
+                    .catch((error: any) => {
+                        setLoading(false);
+                        setOutput(`Error: ${error.message}`);
+                    });
+
+                break;
+>>>>>>> parent of 65dcab0 (Fix for Traceroute Failing to accept multiple additional flags issue 1217)
         }
     };
 
@@ -256,7 +279,7 @@ const Traceroute = () => {
                 <Stack>
                     {LoadingOverlayAndCancelButton(loading, pid)}
                     <TextInput label={"Hostname/IP address"} {...form.getInputProps("hostname")} />
-                    <TextInput label={"Traceroute custom (optional)"} {...form.getInputProps("traceRouteOptions")} />
+                    <TextInput label={"Traceroute custom (optional)"} {...form.getInputProps("tracerouteOptions")} />
                     <NativeSelect
                         value={selectedScanOption}
                         onChange={(e) => setSelectedTracerouteOption(e.target.value)}

--- a/src/components/Traceroute/Traceroute.tsx
+++ b/src/components/Traceroute/Traceroute.tsx
@@ -123,7 +123,7 @@ const Traceroute = () => {
             // Cancel the loading overlay. The process has completed.
             setLoading(false);
         },
-        [handleProcessData] // Dependency on the handleProcessData callback
+        [handleProcessData], // Dependency on the handleProcessData callback
     );
 
     /**
@@ -133,8 +133,8 @@ const Traceroute = () => {
      * @param {FormValuesType} values - Contains the type of traceroute scan (ICMP, TCP, UDP, custom),
      * the destination hostname, and optional custom traceroute options.
      */
-        
-        // Patched onSubmit handler snippet for "Traceroute custom scan"
+
+    // Patched onSubmit handler snippet for "Traceroute custom scan"
     const onSubmit = async (values: FormValuesType) => {
         setLoading(true);
         let args: string[] = [];
@@ -193,39 +193,33 @@ const Traceroute = () => {
                     });
 
                 break;
-	   // Traceroute custom scan allows specifying additional options        
-           case "Traceroute custom scan": {
-               args = ["/usr/share/ddt/Bash-Scripts/Tracerouteshell.sh"];
-               // Hostname is always the first argument
-     	       args.push(values.hostname);
+            // Traceroute custom scan allows specifying additional options
+            case "Traceroute custom scan": {
+                args = ["/usr/share/ddt/Bash-Scripts/Tracerouteshell.sh"];
+                // Hostname is always the first argument
+                args.push(values.hostname);
 
-          // Combine all custom flags into a single string for second argument
-          const rawFlags = values.traceRouteOptions.trim();
-          if (rawFlags.length > 0) {
-            args.push(rawFlags);
-          }
+                // Combine all custom flags into a single string for second argument
+                const rawFlags = values.traceRouteOptions.trim();
+                if (rawFlags.length > 0) {
+                    args.push(rawFlags);
+                }
 
-              // Execute Traceroute with all arguments
-              CommandHelper.runCommandGetPidAndOutput(
-                  "bash",
-                  args,
-                  handleProcessData,
-                  handleProcessTermination
-              )
-              .then(({ pid, output }) => {
-                  setPid(pid);
-                  setOutput(output);
-                  setAllowSave(true);
-              })
-              .catch((error: any) => {
-                  setLoading(false);
-                  setOutput(`Error: ${error.message}`);
-              });
+                // Execute Traceroute with all arguments
+                CommandHelper.runCommandGetPidAndOutput("bash", args, handleProcessData, handleProcessTermination)
+                    .then(({ pid, output }) => {
+                        setPid(pid);
+                        setOutput(output);
+                        setAllowSave(true);
+                    })
+                    .catch((error: any) => {
+                        setLoading(false);
+                        setOutput(`Error: ${error.message}`);
+                    });
 
-            break;
+                break;
+            }
         }
-   
-       }
     };
 
     /**


### PR DESCRIPTION
The alterations I have made to Traceroute.tsx rectify issue 1217. 

Custom scans now function as intended, previously they had not appropriately appended the flags used in a custom search and in some cases not at all. Now custom commands function as intended.

Once this error was corrected the custom scan failed to operate with multiple flags. I have also corrected this issue as well. As long as the combination of flags is valid for a traditional Traceroute command then they will work as intended.

I have attached a video demonstrating that the tool is now working as intended.
https://youtu.be/J3IFZgntwx0