### PR TITLE
Fix for issue 1259 Nmap tool missing start button

### DIFF
--- a/src/components/NmapTool/NmapTool.tsx
+++ b/src/components/NmapTool/NmapTool.tsx
@@ -219,7 +219,34 @@ function Nmap() {
                             {/* Step 1: Target */}
                             <Stepper.Step label="Target">
                                 <TextInput label="Target IP or Hostname" required {...form.getInputProps("target")} />
+
+                                {/* Quick scan option */}
+                                <Stack align="center" mt="sm">
+                                    <Button
+                                        type="submit"
+                                        disabled={loading}
+                                        onClick={() => {
+                                            setActive(2);
+                                            // Executes a barebones Nmap scan
+                                            onSubmit({
+                                                target: form.values.target,
+                                                ports: "",
+                                                scanType: "sT",
+                                                timing: "T3",
+                                                osDetection: false,
+                                                versionDetection: false,
+                                                scriptscan: "",
+                                                aggressive: false,
+                                                verbose: false,
+                                                noPortscan: false,
+                                            });
+                                        }}
+                                    >
+                                        Run Nmap
+                                    </Button>
+                                </Stack>
                             </Stepper.Step>
+
                             {/* Step 2: Scan Options */}
                             <Stepper.Step label="Scan Options">
                                 <Grid>


### PR DESCRIPTION
I have added a "Run Nmap" button to the first stage of the selection screen so a user simply has to enter an IP address and click on the "Run Nmap" button just underneath input panel for the IP address. This runs a bare bones Nmap scan.

I styled the button to match the aesthetic of the current buttons.

This video demonstrated the button's functionality and the underlying code:
https://youtu.be/pRz1zhAqEEk
