### PR TITLE
Add next step adviser

### DIFF
--- a/src/components/NmapTool/NmapTool.tsx
+++ b/src/components/NmapTool/NmapTool.tsx
@@ -11,8 +11,7 @@ import InstallationModal from "../InstallationModal/InstallationModal";
 import { RenderComponent } from "../UserGuide/UserGuide";
 import AskChatGPT from "../AskChatGPT/AskChatGPT"; // Import the AskChatGPT component
 import ChatGPTOutput from "../AskChatGPT/ChatGPTOutput"; // Import for displaying GPT responses
-import AskCohere from "../AskCohere/AskCohere";
-import CohereOutput from "../AskCohere/CohereOutput";
+import PentestGPT from "../PentestGPT/PentestGPT";
 
 /**
  * Represents the form values for the Nmap component.
@@ -41,6 +40,7 @@ function Nmap() {
     const [pid, setPid] = useState("");
     const [allowSave, setAllowSave] = useState(false);
     const [chatGPTResponse, setChatGPTResponse] = useState(""); // State for ChatGPT response
+    const [pentestAdvice, setPentestAdvice] = useState("");
     const [hasSaved, setHasSaved] = useState(false);
     const [active, setActive] = useState(0);
     const [isCommandAvailable, setIsCommandAvailable] = useState(false);
@@ -50,7 +50,6 @@ function Nmap() {
     // Additional state variables for section visibility
     const [basicOpened, setBasicOpened] = useState(true);
     const [advancedOpened, setAdvancedOpened] = useState(false);
-    const [cohereResponse, setCohereResponse] = useState("");
 
     // Declare constants for the component
     const title = "Nmap";
@@ -354,11 +353,11 @@ function Nmap() {
                                 <ChatGPTOutput output={chatGPTResponse} />
                             </div>
                         )}
-                        <AskCohere toolName={title} output={output} setCohereResponse={setCohereResponse} />
-                        {cohereResponse && (
+                        <PentestGPT toolName={title} output={output} setAdvice={setPentestAdvice} />
+                        {pentestAdvice && (
                             <div style={{ marginTop: "20px" }}>
-                                <h3>Cohere Response:</h3>
-                                <CohereOutput output={cohereResponse} />
+                                <h3>Next Step Adviser Response:</h3>
+                                <ChatGPTOutput output={pentestAdvice} />
                             </div>
                         )}
                     </Stack>

--- a/src/components/PentestGPT/PentestGPT.tsx
+++ b/src/components/PentestGPT/PentestGPT.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react";
+import { Button, Stack, Group, Title, Notification, Text, Paper, Loader } from "@mantine/core";
+import ChatGPTOutput from "../AskChatGPT/ChatGPTOutput";
+import { getTools } from "../RouteWrapper";
+
+interface PentestGPTProps {
+    toolName: string;
+    output: string;
+    setAdvice: (advice: string) => void;
+}
+
+const PentestGPT = ({ toolName, output, setAdvice }: PentestGPTProps) => {
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState("");
+
+    const availableTools = getTools();
+    const toolListForPrompt = availableTools.map((t) => `${t.name} (${t.category})`).join(", ");
+
+    const prompt = `
+    You are a senior penetration tester embedded into a red teaming toolkit called PT-GUI. Your job is to analyze the output of tools and guide the user with tactical follow-up steps, using only tools available in the GUI.
+    
+    The user just completed a scan with:
+    - Tool: ${toolName}
+    - Output:
+    ${output}
+    
+    The following tools are currently available in the GUI, with categories:
+    ${toolListForPrompt}
+    
+    Assume that this tool (e.g., Nmap) is part of a broader red team workflow. Base your advice not only on this output, but on what a skilled attacker would likely do next to exploit, pivot, or escalate.
+    
+    Where possible, connect the suggested tool usage to:
+    - The likely exploitation path (e.g., service vuln → directory brute force → credential leak)
+    - The attacker's goal (e.g., shell access, password extraction, local file inclusion)
+    
+    Instructions:
+    0. Based on the output, clearly state the next goal a skilled attacker would pursue (e.g., fingerprint the web server, find misconfigurations, escalate to shell access). Use a single sentence labeled as “Goal”.
+
+    0.1. Before listing tools, explain that the suggested steps follow a standard penetration testing process:
+    reconnaissance → vulnerability assessment → attack surface expansion. This should appear just below the Goal to give users context.
+
+    1. Suggest 1-3 next steps using only tools from the list.
+    2. For each, provide:
+       - Tool Name
+       - Category
+       - Use Case (e.g., Directory Brute Force, Fingerprinting, SQL Injection Testing)
+       - Command-line style syntax (if applicable)
+       - Tactical Reasoning (from a pentester's perspective)
+       - Expected Output with examples (e.g., HTTP 200 responses, SQL errors, server banners)
+    3. If a tool is not present in PT-GUI, clearly label it: [Not available in GUI - use CLI]
+    4. Avoid generic explanations. Be concise, technically accurate, and focused on exploit paths.
+    
+    Format:
+    1. Tool: [ToolName] [Available in GUI]
+       Category: [e.g., Web Reconnaissance]
+       Use Case: [e.g., Detect outdated software]
+       Command: [example syntax or usage strategy]
+       Reasoning: [Why it's useful after previous output; what to look for]
+       Expected Output: [Headers, codes, version strings, errors, etc.]
+    
+    Respond as an experienced OSCP-level red teamer mentoring a junior analyst. Prioritize clarity, exploit logic, and tactical accuracy.
+`.trim();
+
+    const handleGenerateAdvice = async () => {
+        setAdvice("");
+        setError("");
+        setLoading(true);
+
+        const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+
+        try {
+            const response = await fetch("https://api.openai.com/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${apiKey}`,
+                },
+                body: JSON.stringify({
+                    model: "gpt-4o",
+                    messages: [{ role: "user", content: prompt }],
+                    temperature: 0.7,
+                }),
+            });
+
+            const data = await response.json();
+            const reply = data.choices?.[0]?.message?.content || "No response received from GPT.";
+            setAdvice(reply);
+        } catch (err: any) {
+            console.error("PentestGPT Error:", err);
+            setError("Failed to connect to the OpenAI API. Please check your API key and internet connection.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <Paper shadow="xs" p="md" withBorder mt="lg">
+            <Group position="apart" align="flex-start">
+                <Stack spacing={2}>
+                    <Title order={4}>Next Step Adviser</Title>
+                    <Text size="xs" color="dimmed" italic>
+                        This assistant analyzes the output of the previous tool and suggests one or more relevant
+                        follow-up actions using tools available in the PT-GUI environment.
+                    </Text>
+                </Stack>
+                <Button onClick={handleGenerateAdvice} disabled={!output || loading}>
+                    {loading ? <Loader size="xs" /> : "Generate Advice"}
+                </Button>
+            </Group>
+
+            {error && (
+                <Notification title="Error" color="red" mt="sm">
+                    {error}
+                </Notification>
+            )}
+        </Paper>
+    );
+};
+
+export default PentestGPT;


### PR DESCRIPTION
This update adds a new assistant that shows up after running a tool (e.g. Nmap) to help figure out what to do next. It uses GPT but only recommends tools that are actually available in the PT-GUI, based on what was found in the output.

- Created a new PentestGPT.tsx component that takes tool name and output and sends it to GPT.
- It suggests 1–3 follow-up tools (only GUI tools), with full reasoning and command-style examples.
- Hooked it into the Nmap interface to show how it works in a real use case.
- Uses getTools() from RouteWrapper, so the tool list is always synced.

