### PR TITLE
Docs: Add ADR-0026 for PentestGPT Next Step Adviser feature

### DIFF
--- a/documentation/adr/ADR-0026.md
+++ b/documentation/adr/ADR-0026.md
@@ -1,0 +1,61 @@
+# Title
+
+Integration of PentestGPT: Next Step Adviser Feature in PT-GUI
+
+## Proposal Status
+
+Approved
+
+## Implementation Status
+
+Implemented
+
+## Context
+
+PT-GUI has evolved into a versatile penetration testing toolkit focused on red-teaming and cybersecurity education. It currently includes features such as CVE-based attack vectors, scenario-based AI training, and access to individual tools through a guided graphical interface.
+
+While the AI Scenario Training module provides dynamic, end-to-end penetration testing simulations, there remained a gap in real-time guidance after individual tool execution. Users running a tool like Nmap would receive output but lacked immediate, structured advice on what to do next based on that output.
+
+To bridge this gap, a new AI-based component called PentestGPT (Next Step Adviser) has been introduced. Inspired by CLI-based tools like GreyDGL’s PentestGPT, this feature focuses on providing tactical, output-aware suggestions within the GUI environment of PT-GUI, while strictly enforcing internal tool availability.
+
+## Decision
+
+The PentestGPT feature has been implemented as a dedicated component within tools such as Nmap. It provides real-time, output-aware recommendations using GPT-4o. It analyzes the tool's output and suggests 1–3 highly relevant next steps using only GUI-available tools in PT-GUI. This bridges the learning gap between running a scan and understanding how to act on the results.
+
+Unlike the AI Scenario Training module, which generates a full narrative scenario based on user selections (attack vector, difficulty, tools), PentestGPT operates post-execution, acting as a tactical guide after each scan or operation. It helps users understand the immediate implications of a tool's output, such as when a web server is detected or a certain port is found open.
+
+Unlike the Ask GPT feature, which provides general-purpose responses, PentestGPT is tightly integrated with each tool’s output and focuses strictly on actionable, technical follow-up steps within the red team workflow.
+
+Each recommendation includes the tool name, category, use case, command-line style syntax, red-team style reasoning, and the expected outcome or result (e.g., HTTP 200, server banners, file listings). These responses follow the traditional red-team methodology: Reconnaissance → Vulnerability Assessment → Attack Surface Expansion — and the assistant explains how the suggestions align with this logical process.
+
+This feature adds educational value by simulating how a skilled attacker would pivot based on findings. It acts like a mentor walking the user through what they should focus on next, giving concrete follow-ups that build real-world logic. For learners not yet ready for full scenarios, this targeted advice provides just enough support to keep progressing while developing judgment.
+
+It also promotes proper tool use within PT-GUI. If a recommended tool is not in the GUI, the output makes that clear and suggests running it via CLI instead. This ensures users don't hit dead ends, while also keeping the toolkit self-contained.
+
+## Future Vision
+
+This initial implementation marks the beginning of a longer roadmap inspired by CLI-based automation like GreyDGL’s PentestGPT, but reimagined for GUI-based environments. Future directions include:
+
+-   Backend support to cache previous tool outputs for cross-tool chaining
+-   Session-based memory to track engagement paths
+-   Exportable AI-generated strategy reports
+-   Integration into Reporting modules
+-   Ability to toggle between real-time tactical mode (PentestGPT) and full-scenario simulation (AI Scenario Training)
+
+The combination of PentestGPT and Scenario Training allows PT-GUI to offer both micro (step-by-step) and macro (full-flow) guidance, establishing a unique educational model not found in other GUI-based pentest platforms.
+
+## Consequences
+
+### Positive Consequences
+
+-   Adds AI-driven tactical depth to each tool’s execution phase
+-   Helps users transition from reactive use to strategic thinking
+-   Integrates seamlessly with the existing educational mission of PT-GUI
+-   Promotes tool usage within PT-GUI while acknowledging CLI gaps
+-   Lays groundwork for memory-backed, multi-step analysis in future versions
+
+### Negative Consequences
+
+-   GPT-4o output may vary, requiring careful prompt tuning and periodic reviews
+-   Relies on user-provided OpenAI API key, which may be a barrier for some users
+-   Adds maintenance overhead as more tools and use cases are added

--- a/documentation/adr/adr_register.md
+++ b/documentation/adr/adr_register.md
@@ -20,13 +20,13 @@
 | 0017   | Remove CrackMapExec Tool                                                                      | APPROVED    |
 | 0018   | -empty-                                                                                       | -           |
 | 0019   | Replacement of Wifite with Wifite2                                                            | APPROVED    |
-| 0020   | Integration of AI-Based Scenario Training Feature in PT-GUI                                   | APPROVED    |
+| 0020   | Integration of AI-Based Scenario Training Feature in PT-GUI                                   | IMPLEMENTED |
 | 0021   | Removal of Amap from the Deakin Detonator Toolkit                                             | W-I-P       |
 | 0022   | Add feature to temporarily block access to broken tools                                       | REJECTED    |
 | 0023   | Created an ADR for Anonsurf functionality                                                     | W-I-P       |
 | 0024   | Integration of BetterCap into PT-GUI                                                          | PROPOSED    |
 | 0025   | Addition of Nuclei for Vulnerability Scanning                                                 | PROPOSED    |
-| 0026   | -empty-                                                                                       | -           |
+| 0026   | Integration of PentestGPT as a next step adviser feature in PT-GUI                            | IMPLEMENTED |
 | 0027   | -empty-                                                                                       | -           |
 | 0028   | -empty-                                                                                       | -           |
 | 0029   | -empty-                                                                                       | -           |


### PR DESCRIPTION
This commit adds ADR-0026 documenting the design and rationale behind the new PentestGPT component. The Next Step Adviser feature provides tactical, real-time guidance after tool execution using GPT-4o. It is designed to complement the AI Scenario Training module by offering step-by-step, output-aware follow-up suggestions based on red teaming methodology.

The ADR outlines how the feature improves educational value, how it differs from both AskGPT and Scenario Training, and how it lays the foundation for future memory-backed analysis workflows in PT-GUI. This change helps bridge the gap between tool execution and real-world pentesting logic within the GUI environment.