### PR TITLE
Bug #1374 fix

### DIFF
--- a/src/components/NavBar/MainLinks.tsx
+++ b/src/components/NavBar/MainLinks.tsx
@@ -1,4 +1,4 @@
-import { Group, Text, ThemeIcon, UnstyledButton } from "@mantine/core";
+import { Group, Text, ThemeIcon, UnstyledButton, useMantineTheme } from "@mantine/core";
 import {
     IconHome,
     IconQuestionMark,
@@ -20,21 +20,23 @@ interface MainLinkProps {
 }
 
 function MainLink({ icon, color, label, route }: MainLinkProps) {
+    const theme = useMantineTheme();
     return (
         <UnstyledButton
             sx={(theme) => ({
                 display: "block",
                 width: "100%",
-                padding: theme.spacing.xs,
                 borderRadius: theme.radius.sm,
                 color: theme.colorScheme === "dark" ? theme.colors.dark[0] : theme.black,
-
                 "&:hover": {
                     backgroundColor: theme.colorScheme === "dark" ? theme.colors.dark[6] : theme.colors.gray[0],
                 },
             })}
         >
-            <Link to={route} style={{ textDecoration: "none", color: "inherit" }}>
+            <Link
+                to={route}
+                style={{ textDecoration: "none", color: "inherit", padding: theme.spacing.xs, display: "block" }}
+            >
                 <Group>
                     <ThemeIcon color={color} variant="light">
                         {icon}


### PR DESCRIPTION
The fix was simply moving the padding to the responsive component. The padding was moved from UnstyledButton to Link component. The useMantineTheme() Hook is used to set the same padding in a non-mantine component. After testing adding “0.625rem” also provides the same result (as Mantine uses rem in its css size classes). The performance of both fixes are similar so I selected the useMantineTheme() Hook to keep consistent styling within the script.

<img width="428" height="316" alt="image" src="https://github.com/user-attachments/assets/909a5214-b33b-4bde-9c98-d27b8dd76293" />

Result (Order: Before -> After):
<img width="217" height="258" alt="image" src="https://github.com/user-attachments/assets/06762ada-24b5-408d-89e0-a1a27c2f0c89" />
<img width="199" height="258" alt="image" src="https://github.com/user-attachments/assets/6ee0e752-773e-4442-adb5-a85621a78cf3" />


