### PR TITLE
fix bug#1243 cloudbrute provider flag

### DIFF
--- a/src/components/CloudBrute/CloudBrute.tsx
+++ b/src/components/CloudBrute/CloudBrute.tsx
@@ -226,12 +226,7 @@ const CloudBrute = () => {
                         {...form.getInputProps("domain")}
                     />
                     <TextInput label="Keyword" required placeholder="e.g., test" {...form.getInputProps("keyword")} />
-                    <TextInput
-                        label="Provider"
-                        required
-                        placeholder="google"
-                        {...form.getInputProps("provider")}
-                    />
+                    <TextInput label="Provider" required placeholder="google" {...form.getInputProps("provider")} />
                     <TextInput
                         label="Output fill (full path)"
                         required

--- a/src/components/CloudBrute/CloudBrute.tsx
+++ b/src/components/CloudBrute/CloudBrute.tsx
@@ -15,6 +15,8 @@ import InstallationModal from "../InstallationModal/InstallationModal";
 interface FormValuesType {
     domain: string;
     keyword: string;
+    provider: string;
+    output: string;
     wordlist: string;
 }
 
@@ -56,6 +58,8 @@ const CloudBrute = () => {
         initialValues: {
             domain: "",
             keyword: "",
+            provider: "",
+            output: "/home/kali/Deakin-Detonator-Toolkit/OutputFiles/output.txt",
             wordlist: "/usr/share/dirb/wordlists/common.txt",
         },
     });
@@ -144,10 +148,12 @@ const CloudBrute = () => {
             values.domain,
             "-k",
             values.keyword,
+            "-c",
+            values.provider,
+            "-o",
+            values.output,
             "-w",
             values.wordlist,
-            "--configFolder",
-            "/etc/cloudbrute/config",
         ];
         CommandHelper.runCommandGetPidAndOutput("cloudbrute", args, handleProcessData, handleProcessTermination)
             .then(({ pid, output }) => {
@@ -220,6 +226,18 @@ const CloudBrute = () => {
                         {...form.getInputProps("domain")}
                     />
                     <TextInput label="Keyword" required placeholder="e.g., test" {...form.getInputProps("keyword")} />
+                    <TextInput
+                        label="Provider"
+                        required
+                        placeholder="google"
+                        {...form.getInputProps("provider")}
+                    />
+                    <TextInput
+                        label="Output fill (full path)"
+                        required
+                        placeholder="/home/{YOUR USER NAME}/Deakin-Detonator-Toolkit/OutputFiles/output.txt"
+                        {...form.getInputProps("output")}
+                    />
                     <TextInput
                         label="Path to Wordlist"
                         required

--- a/src/components/CloudBrute/CloudBrute.tsx
+++ b/src/components/CloudBrute/CloudBrute.tsx
@@ -15,8 +15,6 @@ import InstallationModal from "../InstallationModal/InstallationModal";
 interface FormValuesType {
     domain: string;
     keyword: string;
-    provider: string;
-    output: string;
     wordlist: string;
 }
 
@@ -58,8 +56,6 @@ const CloudBrute = () => {
         initialValues: {
             domain: "",
             keyword: "",
-            provider: "",
-            output: "/home/kali/Deakin-Detonator-Toolkit/OutputFiles/output.txt",
             wordlist: "/usr/share/dirb/wordlists/common.txt",
         },
     });
@@ -148,12 +144,10 @@ const CloudBrute = () => {
             values.domain,
             "-k",
             values.keyword,
-            "-c",
-            values.provider,
-            "-o",
-            values.output,
             "-w",
             values.wordlist,
+            "--configFolder",
+            "/etc/cloudbrute/config",
         ];
         CommandHelper.runCommandGetPidAndOutput("cloudbrute", args, handleProcessData, handleProcessTermination)
             .then(({ pid, output }) => {
@@ -226,6 +220,7 @@ const CloudBrute = () => {
                         {...form.getInputProps("domain")}
                     />
                     <TextInput label="Keyword" required placeholder="e.g., test" {...form.getInputProps("keyword")} />
+<<<<<<< HEAD
                     <TextInput label="Provider" required placeholder="google" {...form.getInputProps("provider")} />
                     <TextInput
                         label="Output fill (full path)"
@@ -233,6 +228,8 @@ const CloudBrute = () => {
                         placeholder="/home/{YOUR USER NAME}/Deakin-Detonator-Toolkit/OutputFiles/output.txt"
                         {...form.getInputProps("output")}
                     />
+=======
+>>>>>>> parent of ec9267b (fix bug#1243 cloudbrute provider flag)
                     <TextInput
                         label="Path to Wordlist"
                         required


### PR DESCRIPTION
The Problem:

CloudBrute failed due to missing provider flag.

After provider flag was fixed, Cloudbute was causing a PT-GUI restart each time it was run.

CloudBrute it self has a output file it writes automatically to the root of the running application in this case it was the src-tauri root folder.

THE FIX:

1. Added provider flag to the tool code.
2. Added output flag tot eh tool code
3. Added required GUI code for user entry.

