### PR TITLE
Fix Save Output Bugs in SaveOutputToTextFile

### DIFF
--- a/src/components/SaveOutputToFile/SaveOutputToTextFile.tsx
+++ b/src/components/SaveOutputToFile/SaveOutputToTextFile.tsx
@@ -62,13 +62,13 @@ export function SaveOutputToTextFile_v2(
             setShowError(true);
             return;
         }
-        
+
         if (outputToSave && filename && allowSave) {
             try {
                 // Ensure filename has .txt extension
                 let finalFilename = filename.trim();
-                if (!finalFilename.toLowerCase().endsWith('.txt')) {
-                    finalFilename += '.txt';
+                if (!finalFilename.toLowerCase().endsWith(".txt")) {
+                    finalFilename += ".txt";
                 }
 
                 // Open save dialog with default filename
@@ -76,10 +76,10 @@ export function SaveOutputToTextFile_v2(
                     defaultPath: finalFilename,
                     filters: [
                         {
-                            name: 'Text Files',
-                            extensions: ['txt']
-                        }
-                    ]
+                            name: "Text Files",
+                            extensions: ["txt"],
+                        },
+                    ],
                 });
 
                 // If user didn't cancel the dialog
@@ -90,7 +90,7 @@ export function SaveOutputToTextFile_v2(
                     onSave(); // Call the onSave callback to perform post save actions in caller
                 }
             } catch (error) {
-                console.error('Error saving file:', error);
+                console.error("Error saving file:", error);
                 setShowError(true);
             }
         }


### PR DESCRIPTION
Description

This PR addresses two bugs in the SaveOutputToTextFile component (GitHub Issues #704 and #991):





Empty Filename Bug: Added validation to prevent saving when the filename is empty or whitespace, displaying an error message via Alert component.



Fixed Save Location: Replaced hardcoded output directory with a file save dialog (@tauri-apps/api/dialog) to allow users to choose the save location.

Changes





Added showError state and Alert component to display errors for empty filenames.



Integrated @tauri-apps/api/dialog for user-selected save paths.



Ensured .txt extension is appended to filenames if missing.



Updated save message to display the user-selected file path.



Preserved original functionality of SaveOutputToTextFile (unchanged).

Testing





Verified that saving with an empty filename shows an error and prevents saving.


Confirmed that the save dialog opens, allows custom path selection, and saves the file correctly.

Closes #704 , #991.