### PR TITLE
Fix: Add hash input validation for RainbowCrack tool (#1131)

### DIFF
--- a/src/components/Rainbowcrack/Rainbowcrack.tsx
+++ b/src/components/Rainbowcrack/Rainbowcrack.tsx
@@ -50,6 +50,25 @@ const RainbowCrack = () => {
         initialValues: {
             hashValue: "",
         },
+        validate: {
+            hashValue: (value) => {
+                if (fileNames.length > 0) return null; // skip validation when file is used
+                const normalized = value.trim().toLowerCase();
+
+                const isHex = /^[a-f0-9]+$/.test(normalized);
+
+                if (!isHex) return "Hash must be hexadecimal.";
+
+                const length = normalized.length;
+
+                const validLengths = [32, 40, 64]; // MD5/NTLM/LM, SHA1, SHA256
+                if (!validLengths.includes(length)) {
+                    return "Unsupported hash length. Must be 32, 40, or 64 characters.";
+                }
+
+                return null;
+            },
+        },
     });
 
     useEffect(() => {
@@ -152,6 +171,7 @@ const RainbowCrack = () => {
                             required
                             value={form.values.hashValue}
                             onChange={(event) => form.setFieldValue("hashValue", event.currentTarget.value)}
+                            error={form.errors.hashValue}
                         />
                     ) : (
                         <div>


### PR DESCRIPTION
This PR addresses issue #832 by implementing frontend validation for the hash input field in the RainbowCrack component. The validation ensures that only supported hash formats (LM, NTLM, MD5, SHA1, SHA256) are accepted.

### Changes Made:
- Added regex and length-based validation to the `useForm()` hook in `RainbowCrack.tsx`.
- Only hexadecimal strings with valid lengths (32, 40, 64) are allowed.
- Error messages now appear below the input when invalid hashes are entered.
- Validation is bypassed if a file is uploaded instead of manual input.

### How to Test:
1. Run `npm run dev`.
2. Navigate to the RainbowCrack UI.
3. Try:
   - Invalid hash (e.g., `xyz123!@#`)
   - Unsupported-length hash (e.g., 16 hex chars)
   - Valid MD5/SHA1/SHA256 inputs
   - Upload a hash file instead

### Linked Issue:
Closes #832
