### PR TITLE
Fixed ARP Fingerprint Tool that ignores target IP input and always runs full network scan #1371

### DIFF
--- a/documentation/adr/adr_template.md
+++ b/documentation/adr/adr_template.md
@@ -25,4 +25,4 @@ What is the change that is being proposed and/or implemented? Provide a detailed
 
 ## Consequences
 
-What are the consequences of this decision? Consider what will become easier or more difficult because of this change.
+What are the consequences of this decision? Consider what will become easier or more difficult because of this change

--- a/src/components/arpfingerprint/arpfingerprint.tsx
+++ b/src/components/arpfingerprint/arpfingerprint.tsx
@@ -11,194 +11,183 @@ import { RenderComponent } from "../UserGuide/UserGuide";
 
 /** Form values */
 interface FormValuesType {
-  targetIP: string;
+    targetIP: string;
 }
 
 function ARPFingerprinting() {
-  // State
-  const [loading, setLoading] = useState(false);
-  const [output, setOutput] = useState("");
-  const [allowSave, setAllowSave] = useState(false);
-  const [hasSaved, setHasSaved] = useState(false);
-  const [isCommandAvailable, setIsCommandAvailable] = useState(false);
-  const [opened, setOpened] = useState(!isCommandAvailable);
-  const [loadingModal, setLoadingModal] = useState(true);
-  const [pid, setPid] = useState("");
-  const [showAlert, setShowAlert] = useState(true);
-  const alertTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // State
+    const [loading, setLoading] = useState(false);
+    const [output, setOutput] = useState("");
+    const [allowSave, setAllowSave] = useState(false);
+    const [hasSaved, setHasSaved] = useState(false);
+    const [isCommandAvailable, setIsCommandAvailable] = useState(false);
+    const [opened, setOpened] = useState(!isCommandAvailable);
+    const [loadingModal, setLoadingModal] = useState(true);
+    const [pid, setPid] = useState("");
+    const [showAlert, setShowAlert] = useState(true);
+    const alertTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // UI copy
-  const title = "ARP fingerprint Tool";
-  const description =
-    "ARP fingerprinting is a network reconnaissance technique used to detect the operating systems and devices in a network.";
-  const steps =
-    "Step 1: Enter the IP address of the target device.\n" +
-    "Step 2: Click Scan to start ARP fingerprinting.\n" +
-    "Step 3: View the Output block below to see the fingerprinting results.";
-  const sourceLink = "https://www.kali.org/tools/arp-scan/#arp-fingerprint";
-  const tutorial =
-    "https://docs.google.com/document/d/1PLMdKlXsbzYI9rF25Fo_Gv8aDJvtai0s09hPjM7NA6w/edit?usp=sharing";
+    // UI copy
+    const title = "ARP fingerprint Tool";
+    const description =
+        "ARP fingerprinting is a network reconnaissance technique used to detect the operating systems and devices in a network.";
+    const steps =
+        "Step 1: Enter the IP address of the target device.\n" +
+        "Step 2: Click Scan to start ARP fingerprinting.\n" +
+        "Step 3: View the Output block below to see the fingerprinting results.";
+    const sourceLink = "https://www.kali.org/tools/arp-scan/#arp-fingerprint";
+    const tutorial = "https://docs.google.com/document/d/1PLMdKlXsbzYI9rF25Fo_Gv8aDJvtai0s09hPjM7NA6w/edit?usp=sharing";
 
-  // Check for the exact binary we call
-  const dependencies = ["arp-fingerprint"];
+    // Check for the exact binary we call
+    const dependencies = ["arp-fingerprint"];
 
-  // IPv4-only regex (blocks hostnames, text, CIDR)
-  const ipv4Regex =
-    /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
+    // IPv4-only regex (blocks hostnames, text, CIDR)
+    const ipv4Regex = /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
 
-  // Form
-  const form = useForm<FormValuesType>({
-    initialValues: { targetIP: "" },
-    validate: {
-      targetIP: (value) =>
-        ipv4Regex.test(value.trim())
-          ? null
-          : "Enter a valid IPv4 address, e.g., 192.168.1.1",
-    },
-  });
+    // Form
+    const form = useForm<FormValuesType>({
+        initialValues: { targetIP: "" },
+        validate: {
+            targetIP: (value) =>
+                ipv4Regex.test(value.trim()) ? null : "Enter a valid IPv4 address, e.g., 192.168.1.1",
+        },
+    });
 
-  // Dependency check + disclaimer auto-hide
-  useEffect(() => {
-    checkAllCommandsAvailability(dependencies)
-      .then((isAvailable) => {
-        setIsCommandAvailable(isAvailable);
-        setOpened(!isAvailable);
-        setLoadingModal(false);
-      })
-      .catch((err) => {
-        console.error("Command availability check failed:", err);
-        setLoadingModal(false);
-      });
+    // Dependency check + disclaimer auto-hide
+    useEffect(() => {
+        checkAllCommandsAvailability(dependencies)
+            .then((isAvailable) => {
+                setIsCommandAvailable(isAvailable);
+                setOpened(!isAvailable);
+                setLoadingModal(false);
+            })
+            .catch((err) => {
+                console.error("Command availability check failed:", err);
+                setLoadingModal(false);
+            });
 
-    alertTimeout.current = setTimeout(() => setShowAlert(false), 5000);
-    return () => {
-      if (alertTimeout.current) clearTimeout(alertTimeout.current);
+        alertTimeout.current = setTimeout(() => setShowAlert(false), 5000);
+        return () => {
+            if (alertTimeout.current) clearTimeout(alertTimeout.current);
+        };
+    }, []);
+
+    const handleShowAlert = () => {
+        setShowAlert(true);
+        if (alertTimeout.current) clearTimeout(alertTimeout.current);
+        alertTimeout.current = setTimeout(() => setShowAlert(false), 5000);
     };
-  }, []);
 
-  const handleShowAlert = () => {
-    setShowAlert(true);
-    if (alertTimeout.current) clearTimeout(alertTimeout.current);
-    alertTimeout.current = setTimeout(() => setShowAlert(false), 5000);
-  };
+    // Append process output
+    const handleProcessData = useCallback((data: string) => {
+        setOutput((prev) => (prev ? prev + "\n" + data : data));
+    }, []);
 
-  // Append process output
-  const handleProcessData = useCallback((data: string) => {
-    setOutput((prev) => (prev ? prev + "\n" + data : data));
-  }, []);
+    // Process termination
+    const handleProcessTermination = useCallback(
+        ({ code, signal }: { code: number; signal: number | null }) => {
+            if (code === 0) {
+                handleProcessData("\nARP fingerprinting completed successfully.");
+            } else if (signal === 15) {
+                handleProcessData("\nARP fingerprinting was manually terminated.");
+            } else {
+                handleProcessData(`\nARP fingerprinting terminated with exit code: ${code} and signal code: ${signal}`);
+            }
+            setLoading(false);
+            setAllowSave(true);
+            setHasSaved(false);
+        },
+        [handleProcessData]
+    );
 
-  // Process termination
-  const handleProcessTermination = useCallback(
-    ({ code, signal }: { code: number; signal: number | null }) => {
-      if (code === 0) {
-        handleProcessData("\nARP fingerprinting completed successfully.");
-      } else if (signal === 15) {
-        handleProcessData("\nARP fingerprinting was manually terminated.");
-      } else {
-        handleProcessData(
-          `\nARP fingerprinting terminated with exit code: ${code} and signal code: ${signal}`
-        );
-      }
-      setLoading(false);
-      setAllowSave(true);
-      setHasSaved(false);
-    },
-    [handleProcessData]
-  );
+    const handleSaveComplete = () => {
+        setHasSaved(true);
+        setAllowSave(false);
+    };
 
-  const handleSaveComplete = () => {
-    setHasSaved(true);
-    setAllowSave(false);
-  };
+    // Submit handler — single-host run (correct argv order)
+    const onSubmit = async (values: FormValuesType) => {
+        const { hasErrors } = form.validate();
+        if (hasErrors) return;
 
-  // Submit handler — single-host run (correct argv order)
-  const onSubmit = async (values: FormValuesType) => {
-    const { hasErrors } = form.validate();
-    if (hasErrors) return;
+        setLoading(true);
+        setAllowSave(false);
+        setOutput(""); // clear console (optional)
 
-    setLoading(true);
-    setAllowSave(false);
-    setOutput(""); // clear console (optional)
+        const args = [values.targetIP.trim()];
 
-    const args = [values.targetIP.trim()];
+        CommandHelper.runCommandWithPkexec("arp-fingerprint", args, handleProcessData, handleProcessTermination)
+            .then(({ output, pid }) => {
+                setOutput(output);
+                setPid(pid);
+            })
+            .catch((error) => {
+                setOutput(`Error: ${error.message}`);
+                setLoading(false);
+            });
+    };
 
-    CommandHelper.runCommandWithPkexec(
-      "arp-fingerprint",
-      args,
-      handleProcessData,
-      handleProcessTermination
-    )
-      .then(({ output, pid }) => {
-        setOutput(output);
-        setPid(pid);
-      })
-      .catch((error) => {
-        setOutput(`Error: ${error.message}`);
-        setLoading(false);
-      });
-  };
+    const clearOutput = useCallback(() => {
+        setOutput("");
+        setHasSaved(false);
+        setAllowSave(false);
+    }, []);
 
-  const clearOutput = useCallback(() => {
-    setOutput("");
-    setHasSaved(false);
-    setAllowSave(false);
-  }, []);
+    return (
+        <>
+            <RenderComponent
+                title={title}
+                description={description}
+                steps={steps}
+                tutorial={tutorial}
+                sourceLink={sourceLink}
+            >
+                {!loadingModal && (
+                    <InstallationModal
+                        isOpen={opened}
+                        setOpened={setOpened}
+                        feature_description={description}
+                        dependencies={dependencies}
+                    />
+                )}
 
-  return (
-    <>
-      <RenderComponent
-        title={title}
-        description={description}
-        steps={steps}
-        tutorial={tutorial}
-        sourceLink={sourceLink}
-      >
-        {!loadingModal && (
-          <InstallationModal
-            isOpen={opened}
-            setOpened={setOpened}
-            feature_description={description}
-            dependencies={dependencies}
-          />
-        )}
+                <form onSubmit={form.onSubmit(onSubmit)}>
+                    <Group position="right">
+                        {!showAlert && (
+                            <Button onClick={handleShowAlert} size="xs" variant="outline" color="gray">
+                                Show Disclaimer
+                            </Button>
+                        )}
+                    </Group>
 
-        <form onSubmit={form.onSubmit(onSubmit)}>
-          <Group position="right">
-            {!showAlert && (
-              <Button onClick={handleShowAlert} size="xs" variant="outline" color="gray">
-                Show Disclaimer
-              </Button>
-            )}
-          </Group>
+                    {LoadingOverlayAndCancelButton(loading, pid)}
 
-          {LoadingOverlayAndCancelButton(loading, pid)}
+                    {showAlert && (
+                        <Alert title="Warning: Potential Risks" color="red">
+                            Use this tool only on networks you own or have explicit permission to test.
+                        </Alert>
+                    )}
 
-          {showAlert && (
-            <Alert title="Warning: Potential Risks" color="red">
-              Use this tool only on networks you own or have explicit permission to test.
-            </Alert>
-          )}
+                    <Stack>
+                        <TextInput
+                            label="Target IP address"
+                            placeholder="e.g., 192.168.1.1"
+                            required
+                            {...form.getInputProps("targetIP")}
+                        />
 
-          <Stack>
-            <TextInput
-              label="Target IP address"
-              placeholder="e.g., 192.168.1.1"
-              required
-              {...form.getInputProps("targetIP")}
-            />
+                        {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
 
-            {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
+                        <Button type="submit" disabled={loading}>
+                            Start {title}
+                        </Button>
 
-            <Button type="submit" disabled={loading}>
-              Start {title}
-            </Button>
-
-            <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
-          </Stack>
-        </form>
-      </RenderComponent>
-    </>
-  );
+                        <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
+                    </Stack>
+                </form>
+            </RenderComponent>
+        </>
+    );
 }
 
 export default ARPFingerprinting;

--- a/src/components/arpfingerprint/arpfingerprint.tsx
+++ b/src/components/arpfingerprint/arpfingerprint.tsx
@@ -9,224 +9,196 @@ import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 import InstallationModal from "../InstallationModal/InstallationModal";
 import { RenderComponent } from "../UserGuide/UserGuide";
 
-/**
- * Represents the form values for the ARPfingerprint component.
- */
+/** Form values */
 interface FormValuesType {
-    interface: string;
+  targetIP: string;
 }
 
-/**
- * The ARPfingerprint component.
- * @returns The ARPfingerprint component.
- */
 function ARPFingerprinting() {
-    // Component State Variables.
-    const [loading, setLoading] = useState(false); // State variable to indicate loading state.
-    const [output, setOutput] = useState(""); // State variable to store the output of the command execution.
-    const [allowSave, setAllowSave] = useState(false); // State variable to allow saving the output to a file.
-    const [hasSaved, setHasSaved] = useState(false); // State variable to indicate if the output has been saved.
-    const [isCommandAvailable, setIsCommandAvailable] = useState(false); // State variable to check if the command is available.
-    const [opened, setOpened] = useState(!isCommandAvailable); // State variable to check if the installation modal is open.
-    const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state for the installation modal.
-    const [pid, setPid] = useState(""); // State variable to store the process ID of the command execution.
-    const [showAlert, setShowAlert] = useState(true);
-    const alertTimeout = useRef<NodeJS.Timeout | null>(null);
+  // State
+  const [loading, setLoading] = useState(false);
+  const [output, setOutput] = useState("");
+  const [allowSave, setAllowSave] = useState(false);
+  const [hasSaved, setHasSaved] = useState(false);
+  const [isCommandAvailable, setIsCommandAvailable] = useState(false);
+  const [opened, setOpened] = useState(!isCommandAvailable);
+  const [loadingModal, setLoadingModal] = useState(true);
+  const [pid, setPid] = useState("");
+  const [showAlert, setShowAlert] = useState(true);
+  const alertTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    // Component Constants.
-    const title = "ARP fingerprint Tool"; // Title of the component.
-    const description =
-        "ARP fingerprinting is a network reconnaissance technique used to detect the operating systems and devices in a network."; // Description of the component.
-    const steps = "Step 1: Enter the IP address of the target device.\n";
-    ("Step 2: Click Scan to start ARP fingerprinting.\n");
-    ("Step 3: View the Output block below to see the fingerprinting results.");
-    const sourceLink = "https://www.kali.org/tools/arp-scan/#arp-fingerprint"; // Link to the source code or Kali Tools page.
-    const tutorial = "https://docs.google.com/document/d/1PLMdKlXsbzYI9rF25Fo_Gv8aDJvtai0s09hPjM7NA6w/edit?usp=sharing"; // Link to the official documentation/tutorial.
-    const dependencies = ["arp-scan"]; // Dependencies required for the ARPfingerprint tool.
+  // UI copy
+  const title = "ARP fingerprint Tool";
+  const description =
+    "ARP fingerprinting is a network reconnaissance technique used to detect the operating systems and devices in a network.";
+  const steps =
+    "Step 1: Enter the IP address of the target device.\n" +
+    "Step 2: Click Scan to start ARP fingerprinting.\n" +
+    "Step 3: View the Output block below to see the fingerprinting results.";
+  const sourceLink = "https://www.kali.org/tools/arp-scan/#arp-fingerprint";
+  const tutorial =
+    "https://docs.google.com/document/d/1PLMdKlXsbzYI9rF25Fo_Gv8aDJvtai0s09hPjM7NA6w/edit?usp=sharing";
 
-    // Form hook to handle form input.
-    const form = useForm<FormValuesType>({
-        initialValues: {
-            interface: "",
-        },
-    });
+  // Check for the exact binary we call
+  const dependencies = ["arp-fingerprint"];
 
-    // Check the availability of all commands in the dependencies array.
-    useEffect(() => {
-        // Check if the command is available and set the state variables accordingly.
-        checkAllCommandsAvailability(dependencies)
-            .then((isAvailable) => {
-                setIsCommandAvailable(isAvailable); // Set the command availability state
-                setOpened(!isAvailable); // Set the modal state to opened if the command is not available
-                setLoadingModal(false); // Set loading to false after the check is done
-            })
-            .catch((error) => {
-                console.error("An error occurred:", error);
-                setLoadingModal(false); // Also set loading to false in case of error
-            });
-        // Set timeout to remove alert after 5 seconds on load.
-        alertTimeout.current = setTimeout(() => {
-            setShowAlert(false);
-        }, 5000);
+  // IPv4-only regex (blocks hostnames, text, CIDR)
+  const ipv4Regex =
+    /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
 
-        return () => {
-            if (alertTimeout.current) {
-                clearTimeout(alertTimeout.current);
-            }
-        };
-    }, []);
+  // Form
+  const form = useForm<FormValuesType>({
+    initialValues: { targetIP: "" },
+    validate: {
+      targetIP: (value) =>
+        ipv4Regex.test(value.trim())
+          ? null
+          : "Enter a valid IPv4 address, e.g., 192.168.1.1",
+    },
+  });
 
-    const handleShowAlert = () => {
-        setShowAlert(true);
-        if (alertTimeout.current) {
-            clearTimeout(alertTimeout.current);
-        }
-        alertTimeout.current = setTimeout(() => {
-            setShowAlert(false);
-        }, 5000);
+  // Dependency check + disclaimer auto-hide
+  useEffect(() => {
+    checkAllCommandsAvailability(dependencies)
+      .then((isAvailable) => {
+        setIsCommandAvailable(isAvailable);
+        setOpened(!isAvailable);
+        setLoadingModal(false);
+      })
+      .catch((err) => {
+        console.error("Command availability check failed:", err);
+        setLoadingModal(false);
+      });
+
+    alertTimeout.current = setTimeout(() => setShowAlert(false), 5000);
+    return () => {
+      if (alertTimeout.current) clearTimeout(alertTimeout.current);
     };
+  }, []);
 
-    /**
-     * handleProcessData: Callback to handle and append new data from the child process to the output.
-     * It updates the state by appending the new data received to the existing output.
-     * @param {string} data - The data received from the child process.
-     */
-    const handleProcessData = useCallback((data: string) => {
-        setOutput((prevOutput) => prevOutput + "\n" + data);
-    }, []);
+  const handleShowAlert = () => {
+    setShowAlert(true);
+    if (alertTimeout.current) clearTimeout(alertTimeout.current);
+    alertTimeout.current = setTimeout(() => setShowAlert(false), 5000);
+  };
 
-    /**
-     * handleProcessTermination: Callback to handle the termination of the child process.
-     * Once the process termination is handled, it clears the process PID reference and
-     * deactivates the loading overlay.
-     * @param {object} param - An object containing information about the process termination.
-     * @param {number} param.code - The exit code of the terminated process.
-     * @param {number} param.signal - The signal code indicating how the process was terminated.
-     */
-    const handleProcessTermination = useCallback(
-        ({ code, signal }: { code: number; signal: number }) => {
-            // If the process was successful, display a success message.
-            if (code === 0) {
-                handleProcessData("\nARP fingerprinting completed successfully.");
+  // Append process output
+  const handleProcessData = useCallback((data: string) => {
+    setOutput((prev) => (prev ? prev + "\n" + data : data));
+  }, []);
 
-                // If the process was terminated manually, display a termination message.
-            } else if (signal === 15) {
-                handleProcessData("\nARP fingerprinting was manually terminated.");
+  // Process termination
+  const handleProcessTermination = useCallback(
+    ({ code, signal }: { code: number; signal: number | null }) => {
+      if (code === 0) {
+        handleProcessData("\nARP fingerprinting completed successfully.");
+      } else if (signal === 15) {
+        handleProcessData("\nARP fingerprinting was manually terminated.");
+      } else {
+        handleProcessData(
+          `\nARP fingerprinting terminated with exit code: ${code} and signal code: ${signal}`
+        );
+      }
+      setLoading(false);
+      setAllowSave(true);
+      setHasSaved(false);
+    },
+    [handleProcessData]
+  );
 
-                // If the process was terminated with an error, display the exit and signal codes.
-            } else {
-                handleProcessData(`\nARP fingerprinting terminated with exit code: ${code} and signal code: ${signal}`);
-            }
+  const handleSaveComplete = () => {
+    setHasSaved(true);
+    setAllowSave(false);
+  };
 
-            // Cancel the loading overlay. The process has completed.
-            setLoading(false);
+  // Submit handler — single-host run (correct argv order)
+  const onSubmit = async (values: FormValuesType) => {
+    const { hasErrors } = form.validate();
+    if (hasErrors) return;
 
-            // Now that loading has completed, allow the user to save the output to a file.
-            setAllowSave(true);
-            setHasSaved(false);
-        },
-        [handleProcessData] // Dependency on the handleProcessData callback
-    );
+    setLoading(true);
+    setAllowSave(false);
+    setOutput(""); // clear console (optional)
 
-    /**
-     * handleSaveComplete: Recognizes that the output file has been saved.
-     * Passes the saved status back to SaveOutputToTextFile_v2.
-     */
-    const handleSaveComplete = () => {
-        setHasSaved(true);
-        setAllowSave(false);
-    };
+    const args = [values.targetIP.trim()];
 
-    /**
-     * onSubmit: Asynchronous handler for the form submission event.
-     * It sets up and triggers the ARPfingerprint tool with the given parameters.
-     * Once the command is executed, the results or errors are displayed in the output.
-     *@param {FormValuesType} values - The form values, containing target IP.     */
-    const onSubmit = async (values: FormValuesType) => {
-        // Set the loading state to true to indicate that the process is starting.
-        setLoading(true);
+    CommandHelper.runCommandWithPkexec(
+      "arp-fingerprint",
+      args,
+      handleProcessData,
+      handleProcessTermination
+    )
+      .then(({ output, pid }) => {
+        setOutput(output);
+        setPid(pid);
+      })
+      .catch((error) => {
+        setOutput(`Error: ${error.message}`);
+        setLoading(false);
+      });
+  };
 
-        // Disable saving the output to a file while the process is running.
-        setAllowSave(false);
+  const clearOutput = useCallback(() => {
+    setOutput("");
+    setHasSaved(false);
+    setAllowSave(false);
+  }, []);
 
-        // Construct the arguments for the ARPfingerprint command.
-        const args = [`-l`, values.interface];
-        // Execute the ARPFingerprint command via helper method and handle its output or potential errors
-        CommandHelper.runCommandWithPkexec("arp-fingerprint", args, handleProcessData, handleProcessTermination)
-            .then(({ output, pid }) => {
-                setOutput(output);
-                setPid(pid);
-            })
-            .catch((error) => {
-                // Display any errors encountered during command execution
-                setOutput(`Error: ${error.message}`);
-                // Deactivate loading state
-                setLoading(false);
-            });
-    };
+  return (
+    <>
+      <RenderComponent
+        title={title}
+        description={description}
+        steps={steps}
+        tutorial={tutorial}
+        sourceLink={sourceLink}
+      >
+        {!loadingModal && (
+          <InstallationModal
+            isOpen={opened}
+            setOpened={setOpened}
+            feature_description={description}
+            dependencies={dependencies}
+          />
+        )}
 
-    /**
-     * clearOutput: Callback function to clear the console output.
-     * It resets the state variable holding the output, thereby clearing the display.
-     */
-    const clearOutput = useCallback(() => {
-        setOutput("");
-        setHasSaved(false);
-        setAllowSave(false);
-    }, []);
+        <form onSubmit={form.onSubmit(onSubmit)}>
+          <Group position="right">
+            {!showAlert && (
+              <Button onClick={handleShowAlert} size="xs" variant="outline" color="gray">
+                Show Disclaimer
+              </Button>
+            )}
+          </Group>
 
-    return (
-        <>
-            {/* Render the UserGuide component with component details */}
-            <RenderComponent
-                title={title}
-                description={description}
-                steps={steps}
-                tutorial={tutorial}
-                sourceLink={sourceLink}
-            >
-                {/* Render the installation modal if the command is not available */}
-                {!loadingModal && (
-                    <InstallationModal
-                        isOpen={opened}
-                        setOpened={setOpened}
-                        feature_description={description}
-                        dependencies={dependencies}
-                    ></InstallationModal>
-                )}
-                <form onSubmit={form.onSubmit(onSubmit)}>
-                    <Group position="right">
-                        {!showAlert && (
-                            <Button onClick={handleShowAlert} size="xs" variant="outline" color="gray">
-                                Show Disclaimer
-                            </Button>
-                        )}
-                    </Group>
-                    {/* Render the loading overlay and cancel button */}
-                    {LoadingOverlayAndCancelButton(loading, pid)}
+          {LoadingOverlayAndCancelButton(loading, pid)}
 
-                    {showAlert && (
-                        <Alert title="Warning: Potential Risks" color="red">
-                            This tool is used to perform ARP fingerprinting, use with caution and only on networks you
-                            own or have explicit permission to test.
-                        </Alert>
-                    )}
+          {showAlert && (
+            <Alert title="Warning: Potential Risks" color="red">
+              Use this tool only on networks you own or have explicit permission to test.
+            </Alert>
+          )}
 
-                    <Stack>
-                        <TextInput label="Target IP address" required {...form.getInputProps("targetIP")} />
-                        {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
+          <Stack>
+            <TextInput
+              label="Target IP address"
+              placeholder="e.g., 192.168.1.1"
+              required
+              {...form.getInputProps("targetIP")}
+            />
 
-                        <Button type={"submit"} disabled={loading}>
-                            Start {title}
-                        </Button>
+            {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
 
-                        {/* Render the console wrapper component */}
-                        <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
-                    </Stack>
-                </form>
-            </RenderComponent>
-        </>
-    );
+            <Button type="submit" disabled={loading}>
+              Start {title}
+            </Button>
+
+            <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
+          </Stack>
+        </form>
+      </RenderComponent>
+    </>
+  );
 }
 
 export default ARPFingerprinting;


### PR DESCRIPTION
**Description**
This PR resolves the ARP Fingerprint Tool’s input handling issue (GitHub Issue #1371):

- Ignored Input Bug: Fixed the problem where the "Target IP address" field was ignored and the tool always executed pkexec arp-fingerprint -l, causing a full network scan regardless of input validity.
- Solution: Implemented IPv4-only validation for the input field and updated the command execution logic to run pkexec arp-fingerprint <IP> only when a valid IP is provided, preventing unintended LAN sweeps.

**Changes**
Updated ARPFingerprinting.tsx:
- Added regex-based IPv4 validation in the Mantine form to block non-IP inputs.
- Removed the hardcoded -l argument from the command builder.
- Passed only the validated IP to arp-fingerprint for single-host scanning.
- Improved error handling to display validation errors and block execution when input is invalid.
- Ensured no impact on other tools or components in the toolkit.

**Testing**

- Entering a valid IPv4 (e.g., 172.16.131.2) runs a single-host fingerprint successfully.
- Entering an invalid string (e.g., abc) shows a validation error and prevents execution.
- Confirmed that separate LAN scan functionality remains unaffected.

Closes #1371