### PR TITLE
Fix: Added Nuclei tool to References page (#1380)

### DIFF
--- a/src/pages/References.tsx
+++ b/src/pages/References.tsx
@@ -328,6 +328,11 @@ const ReferencesPage = () => {
                                     url={"https://www.nmap.org"}
                                 />
                                 <Reference
+                                    name="Nuclei"
+                                    description="Nuclei is a fast vulnerability scanner powered by community and custom templates."
+                                    url={"https://www.kali.org/tools/nuclei/"}
+                                />
+                                <Reference
                                     name={"NSLookup"}
                                     description={"NSlookup  is  a program to query Internet domain name servers."}
                                     url={"https://www.kali.org/tools/bind9/#nslookup"}


### PR DESCRIPTION
### Summary
This PR adds the Nuclei tool to the References page.

### Related Issue
Fixes #1380

### Changes
- Updated `References.tsx` to include Nuclei tool entry.

### Notes
This change is part of the ongoing tool reference updates. Verified build works locally with no issues.
