### PR TITLE
[Bug Fix #1389]: Fixed light mode in Cyber News section

### DIFF
--- a/src/components/NewsFeed/NewsFeed.tsx
+++ b/src/components/NewsFeed/NewsFeed.tsx
@@ -200,7 +200,7 @@ ${item.description}
                                 withBorder
                                 p="md"
                                 mb="sm"
-                                style={{ backgroundColor: "#1f1f1f", ...styles }}
+                                style={styles}
                             >
                                 <Group position="apart" style={{ marginBottom: "0.5rem" }}>
                                     <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>

--- a/src/components/NewsFeed/NewsFeed.tsx
+++ b/src/components/NewsFeed/NewsFeed.tsx
@@ -194,14 +194,7 @@ ${item.description}
                 return (
                     <Transition key={index} mounted transition="fade" duration={400} timingFunction="ease">
                         {(styles) => (
-                            <Card
-                                shadow="xs"
-                                radius="md"
-                                withBorder
-                                p="md"
-                                mb="sm"
-                                style={styles}
-                            >
+                            <Card shadow="xs" radius="md" withBorder p="md" mb="sm" style={styles}>
                                 <Group position="apart" style={{ marginBottom: "0.5rem" }}>
                                     <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
                                         <a


### PR DESCRIPTION
Fixed light mode styling in Cyber News cards.

- Removed hard coded dark background (#1f1f1f) from Card components to allow proper theme switching between light and dark modes