### PR TITLE
bug#1410 fix ffuf command not found

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,10 +18,10 @@
                 "sidecar": true,
                 "scope": [
                     {
-    			"name": "nmap",
-   			"cmd": "/usr/bin/nmap",
-    			"args": true
-		    },
+                        "name": "nmap",
+                        "cmd": "/usr/bin/nmap",
+                        "args": true
+                    },
                     {
                         "name": "airbase-ng",
                         "cmd": "airbase-ng",
@@ -153,6 +153,11 @@
                         "args": true
                     },
                     {
+                        "name": "ffuf",
+                        "cmd": "ffuf",
+                        "args": true
+                    },
+                    {
                         "name": "find",
                         "cmd": "find",
                         "args": true
@@ -252,7 +257,7 @@
                         "cmd": "nslookup",
                         "args": true
                     },
-                                        {
+                    {
                         "name": "nuclei",
                         "cmd": "nuclei",
                         "args": true
@@ -337,7 +342,7 @@
                         "cmd": "subjack",
                         "args": true
                     },
-                      
+
                     {
                         "name": "sublist3r",
                         "cmd": "sublist3r",
@@ -398,7 +403,7 @@
                         "cmd": "whois",
                         "args": true
                     },
-                  
+
                     {
                         "name": "wpscan",
                         "cmd": "wpscan",
@@ -412,23 +417,22 @@
                 ]
             },
             "fs": {
-                "all": true,                            
-                "writeFile": true,                      
+                "all": true,
+                "writeFile": true,
                 "scope": [
-                  "$TEMP/**",
-                  "$HOME/Deakin-Detonator-Toolkit/**",
-                  "$HOME/Deakin-Detonator-Toolkit/OutputFiles/**",
-                  "$DESKTOP/**"                             
+                    "$TEMP/**",
+                    "$HOME/Deakin-Detonator-Toolkit/**",
+                    "$HOME/Deakin-Detonator-Toolkit/OutputFiles/**",
+                    "$DESKTOP/**"
                 ]
-              },
-              "dialog": {
-                "all": true,                            
-                "save": true                            
-              },
-              "path": {
+            },
+            "dialog": {
+                "all": true,
+                "save": true
+            },
+            "path": {
                 "all": true
-              }
-              
+            }
         },
         "bundle": {
             "active": true,


### PR DESCRIPTION
the problem:

Running ffuf tool would cause the cancel button to become non inactive and an error "scoped command ffuf not found" would be in the terminal.

the fix:

Added ffuf to tauri.conf.json as it seemed it had been removed in a merge that re-ordered the tools into alphabetical order. ffuf was missed during the merge and never fixed. 