### PR TITLE
bug#1418 update debian repo info

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ To install Deakin Detonator Toolkit on Kali, you can follow the method below. Th
 4. Add the following as new lines to your APT sources list:
 
     ```bash
-    deb http://security.debian.org/debian-security buster/updates main
-    deb http://ftp.au.debian.org/debian buster main
+    deb http://deb.debian.org/debian-security/ bookworm-security main contrib non-free non-free-firmware
+    deb http://deb.debian.org/debian/ bookworm main contrib non-free non-free-firmware
     ```
 
 5. Update Kali again:


### PR DESCRIPTION
the problem:

README.md file had outdated Debian repository information that would stop the apt update if implemented as instructed.

the fix:

removed old buster repository information.
add bookworm repository information . 

NOTE: bookworm has now become old-stable under Debian release cycle as it will only have a couple of years before it will not be usable at best. this is a major issue as Debian will no longer support the libwebkit2gtk-4.0 after bookworm and will only have libwebkit2gtk-4.1 . this means tauri will have to be upgraded  from tauri v1 to tauri v2.