### PR TITLE
Solution to issue #1373

### DIFF
--- a/install-update-media/setup_ddt.sh
+++ b/install-update-media/setup_ddt.sh
@@ -3,14 +3,13 @@
 set -e
 
 # Add Debian security updates and main repository to sources.list if not already added
-# NOTE: ^ indicates string pattern starts on a new line. Avoids matching with hash version, e.g.: #deb
-#grep -q "^deb http://security.debian.org/debian-security buster/updates main" "/etc/apt/sources.list" && echo 'Already added Debian security to sources.list.' || sudo sh -c 'echo "deb http://security.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list'
-#grep -q "^deb http://ftp.au.debian.org/debian buster main" "/etc/apt/sources.list" && echo 'Already added Debian to sources.list.' || sudo sh -c 'echo "deb http://ftp.au.debian.org/debian buster main" >> /etc/apt/sources.list'
 sources_file="/etc/apt/sources.list"
 
-# Lines to add
-security_line="deb http://security.debian.org/debian-security buster/updates main"
-main_line="deb http://ftp.au.debian.org/debian buster main"
+# Please regularly check that the debian repostiories in use are still supported otherwise installation will fail and Kali will fail to update.
+# Caution must be taken when adjusting the following repositories as the will be added to the critical system file "etc/apt/sources.list" 
+security_line="deb http://deb.debian.org/debian-security/ bookworm-security main contrib non-free non-free-firmware"
+main_line="deb http://deb.debian.org/debian/ bookworm main contrib non-free non-free-firmware"
+
 
 # Function to add a line (skipping commented-out lines during the existence check)
 add_line_if_not_exists() {


### PR DESCRIPTION
Date fixed: 03/09/2025
Tested by: James Dunn (MetricDunn)

DDT setup script failure #1373:
https://github.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/issues/1373

Issue description:
The current repositories added to "sources.list" are no longer valid. This results in Kali being unable to update and can result in the application failing to operate.

Date reported: 04/08/2025
Reported by: MetricDunn

Fix summary:
I removed the current repositories that were redundant and replaced them with current repositories that are still receiving support and will continue to receive support for approximately two years. I also removed redundant code comments.

Files changed:
Deakin-Detonator-Toolkit/install-update-media/setup_ddt.sh

Commit reference:
https://github.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/tree/issue-1373-setup-fix

Testing Result:
I tested the new install script on three different virtual machines and Abdalla Takla (@ataklaSec) also tested the script and it successfully installed DDT. To test the changes simply run the install script and wait for the task to finish and DDT should operate as intended.