### PR TITLE
[Bug Fix #1460]: Fixed dupliciate CVE-2022-27925 entries in References page

### DIFF
--- a/src/pages/References.tsx
+++ b/src/pages/References.tsx
@@ -555,11 +555,6 @@ const ReferencesPage = () => {
                                     url={"https://github.com/M4xSec/Apache-APISIX-CVE-2022-24112"}
                                 />
                                 <Reference
-                                    name={"CVE-2022-27925"}
-                                    description={"Zimbra Collaboration Suite - Remote Code Execution."}
-                                    url={"https://github.com/M4xSec/Apache-APISIX-CVE-2022-24112"}
-                                />
-                                <Reference
                                     name={"CVE-2022-26134"}
                                     description={"CVE-2022-26134 allows Remote Code Execution."}
                                     url={"https://github.com/hev0x/CVE-2022-26134"}


### PR DESCRIPTION
Resolved duplicate CVE-2022-27925 reference in the Attack Vectors section:
- Removed duplicate entry that incorrectly used the CVE-2022-24112 URL
- Ensured the correct entry uses the Arctic Wolf blog link for CVE-2022-27925