### PR TITLE
Automatic category creation to cover all tools - Bug #1461 fix

### DIFF
--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -1,23 +1,16 @@
 import { Stack, Table, Title, Select, useMantineColorScheme } from "@mantine/core";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { getTools } from "../components/RouteWrapper";
 import ToolItem from "../components/ToolItem/ToolItem";
 
 const ToolsPage = () => {
-    const categories = [
-        "All",
-        "Attack Tools",
-        "File Analysis and Recovery",
-        "Information Gathering and Analysis",
-        "Miscellaneous",
-        "Network Scanning and Enumeration",
-        "Password Cracking and Authentication Testing",
-        "Vulnerability Assessment and Exploitation",
-        "Web Application Testing",
-    ];
-
     const [selectedCategory, setSelectedCategory] = useState("");
     const tools = getTools();
+
+    const categories = useMemo(() => {
+        const uniqueCategories = new Set(tools.map((tool) => tool.category));
+        return ["All", ...Array.from(uniqueCategories).sort()];
+    }, [tools]);
 
     let colorScheme: "light" | "dark" = "light";
     try {


### PR DESCRIPTION
- The problem with the category dropdown was that it was static and outdated. 
- I generate an array of categories from the tools data as the solution. 
- Its wrapped in a useMemo hook to only regenerate the data if the tools’ data changes. This ensures that the dropdown will be UpToDate even if new categories are added 
- Category is mandatory for a tool so I didn’t add extra validation in this component

My comments for suggested fixes in the bug page:
• Enforce Category as a required field for all tools - **Category is already a required field for all tools**
• Backfill missing categories in the data - **All current tools have a category**
• Provide a fallback option in the UI that shows “Uncategorized” if no category is assigned & Ensure the filter includes “Uncategorized” as a selectable value. - **Unnecessary because all current tools have a category**

Before => After

- 
<img width="306" height="351" alt="image" src="https://github.com/user-attachments/assets/c7986b88-dd87-4d72-b328-48775abe6124" />

- 
<img width="292" height="350" alt="image" src="https://github.com/user-attachments/assets/4f7fb9fd-a295-486d-bca0-0aa323e0923f" />


- The performance cost was minimal when tested with the reactor profiler. Since I’m using useMemo, it will only run once when the app first starts, so performance cost could be disregarded.

Before:
<img width="753" height="320" alt="image" src="https://github.com/user-attachments/assets/689fabca-471f-41bf-87a0-7ca85331d1f6" />

After:
<img width="894" height="444" alt="image" src="https://github.com/user-attachments/assets/6f2b2aba-2140-410c-b1ab-72a8a08fa561" />


