### PR TITLE
Bug_Fix_#1455

### DIFF
--- a/src/components/DNSMap/DNSMap.tsx
+++ b/src/components/DNSMap/DNSMap.tsx
@@ -24,41 +24,204 @@ interface FormValuesType {
  * The DNSMap component.
  * @returns The DNSMap component.
  */
-
 const DNSMap = () => {
-    //Componenets state Variable
-    const [loading, setLoading] = useState(false); // State variable that represents loading state of the component
-    const [output, setOutput] = useState(""); // State variable that represents the output text from the DNS mapping process
-    const [checkedAdvanced, setCheckedAdvanced] = useState(false); //State variable that represents the state of advanced mode switch
-    const [Pid, setPid] = useState(""); //State variable that represents the process ID of the DNS mapping process
-    const [allowSave, setAllowSave] = useState(false); //State variable that represents whether saving the output is allowed
-    const [hasSaved, setHasSaved] = useState(false); //State variable that represents whether the output has been saved
-    const [isCommandAvailable, setIsCommandAvailable] = useState(false); // State variable to check if the command is available.
-    const [opened, setOpened] = useState(!isCommandAvailable); // State variable that indicates if the modal is opened.
-    const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state of the modal.
+    // Components state variables
+    const [loading, setLoading] = useState(false);
+    const [output, setOutput] = useState("");
+    const [checkedAdvanced, setCheckedAdvanced] = useState(false);
+    const [Pid, setPid] = useState("");
+    const [allowSave, setAllowSave] = useState(false);
+    const [hasSaved, setHasSaved] = useState(false);
+    const [isCommandAvailable, setIsCommandAvailable] = useState(false);
+    const [opened, setOpened] = useState(!isCommandAvailable);
+    const [loadingModal, setLoadingModal] = useState(true);
     const [showAlert, setShowAlert] = useState(true);
+
+    // Validation/correction messages
+    const [errorMsg, setErrorMsg] = useState<string | null>(null);
+    const [correctionMsg, setCorrectionMsg] = useState<string | null>(null);
+
     const alertTimeout = useRef<NodeJS.Timeout | null>(null);
 
-    //Components Constant Variables
+    // Components Constant Variables
     const title = "Dnsmap";
     const description_userguide =
         "DNSMap scans a domain for common subdomains using a built-in or an external wordlist (if specified using -w option). " +
         "The internal wordlist has around 1000 words in English and Spanish as ns1, firewall services and smtp. " +
         "So it will be possible to search for smtp.example.com inside example.com automatically.\n\n";
+
     const steps =
         "Step 1: Enter a valid domain to be mapped.\n" +
-        "       Eg: google.com\n\n" +
+        " Eg: google.com\n\n" +
         "Step 2: Enter a delay between requests. Default is 10 (milliseconds). Can be left blank.\n" +
-        "       Eg: 10\n\n" +
+        " Eg: 10\n\n" +
         "Step 3: Click 'Start Mapping' to commence the DNSMap tool's operation.\n\n" +
         "Step 4: View the Output block below to view the results of the tool's execution.\n\n" +
         "Switch to Advanced Mode for further options.";
-    const sourceLink = "https://www.kali.org/tools/dnsmap/"; // Link to the source code (or Kali Tools).
-    const tutorial = "https://docs.google.com/document/d/15iZ-USnXOVe-zLBLC_ROp0OTqXO_Nh7WtGO6YHfqQsc/edit?usp=sharing"; // Link to the official documentation/tutorial.
-    const dependencies = ["dnsmap"]; // Contains the dependencies required by the component.
 
-    //Form Hook to handle input
-    let form = useForm({
+    const sourceLink = "https://www.kali.org/tools/dnsmap/";
+    const tutorial = "https://docs.google.com/document/d/15iZ-USnXOVe-zLBLC_ROp0OTqXO_Nh7WtGO6YHfqQsc/edit?usp=sharing";
+    const dependencies = ["dnsmap"];
+
+    // ---------- Domain sanitising / validation / correction ----------
+    const COMMON_TLDS = [
+        "com",
+        "net",
+        "org",
+        "edu",
+        "gov",
+        "io",
+        "co",
+        "au",
+        "uk",
+        "de",
+        "fr",
+        "in",
+        "us",
+        "ca",
+        "nz",
+        "info",
+        "biz",
+        "dev",
+        "app",
+        "ai",
+        "me",
+        "tv",
+        "xyz",
+        "site",
+        "online",
+        "shop",
+        "store",
+        "tech",
+        "cloud",
+        "systems",
+        "solutions",
+    ];
+
+    const TLD_FIXES: Record<string, string> = {
+        con: "com",
+        cpm: "com",
+        ocm: "com",
+        cim: "com",
+        comm: "com",
+        coom: "com",
+        xom: "com",
+    };
+
+    const KNOWN_DOMAINS = [
+        "google.com",
+        "youtube.com",
+        "facebook.com",
+        "github.com",
+        "kali.org",
+        "wikipedia.org",
+        "reddit.com",
+        "instagram.com",
+        "linkedin.com",
+        "amazon.com",
+        "apple.com",
+        "microsoft.com",
+        "netflix.com",
+        "deakin.edu.au",
+        "twitter.com",
+        "x.com",
+    ];
+
+    const sanitiseDomain = (raw: string): string => {
+        let d = raw.trim().toLowerCase();
+        d = d.replace(/^https?:\/\//, ""); // remove protocol
+        d = d.split("/")[0]; // drop path/query
+        d = d.replace(/[\s\u200B-\u200D\uFEFF]/g, ""); // strip zero-width/whitespace
+        return d;
+    };
+
+    const isValidDomainSyntax = (domain: string): boolean => {
+        if (!domain || domain.length > 253) return false;
+        const parts = domain.split(".");
+        if (parts.length < 2) return false;
+
+        const tld = parts[parts.length - 1];
+        if (!/^[a-z]{2,24}$/.test(tld)) return false;
+
+        for (const label of parts) {
+            if (label.length < 1 || label.length > 63) return false;
+            if (!/^[a-z0-9-]+$/.test(label)) return false;
+            if (label.startsWith("-") || label.endsWith("-")) return false;
+        }
+        return true;
+    };
+
+    const levenshtein = (a: string, b: string): number => {
+        const m = a.length,
+            n = b.length;
+        const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+        for (let i = 0; i <= m; i++) dp[i][0] = i;
+        for (let j = 0; j <= n; j++) dp[0][j] = j;
+        for (let i = 1; i <= m; i++) {
+            for (let j = 1; j <= n; j++) {
+                const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+                dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost);
+            }
+        }
+        return dp[m][n];
+    };
+
+    const correctDomainIfObvious = (domain: string): { corrected?: string; reason?: string } => {
+        let d = domain;
+        const parts = d.split(".");
+
+        // Fix obvious TLD mistakes
+        if (parts.length >= 2) {
+            const tld = parts[parts.length - 1];
+            if (TLD_FIXES[tld]) {
+                const fixed = [...parts.slice(0, -1), TLD_FIXES[tld]].join(".");
+                return { corrected: fixed, reason: `Replaced ".${tld}" with ".${TLD_FIXES[tld]}"` };
+            }
+            if (tld.endsWith(",")) {
+                const fixed = [...parts.slice(0, -1), tld.replace(/,+$/, "")].join(".");
+                if (isValidDomainSyntax(fixed)) {
+                    return { corrected: fixed, reason: "Removed trailing comma from TLD" };
+                }
+            }
+        }
+
+        // If TLD is one edit away from a common TLD, fix
+        if (parts.length >= 2) {
+            const tld = parts[parts.length - 1];
+            let bestTld = tld;
+            let bestDist = 99;
+            for (const ct of COMMON_TLDS) {
+                const dist = levenshtein(tld, ct);
+                if (dist < bestDist) {
+                    bestDist = dist;
+                    bestTld = ct;
+                }
+            }
+            if (bestDist > 0 && bestDist <= 1) {
+                const fixed = [...parts.slice(0, -1), bestTld].join(".");
+                return { corrected: fixed, reason: `Did you mean ".${bestTld}"?` };
+            }
+        }
+
+        // Known popular domains by distance (<=2 edits)
+        let best = d;
+        let bestDist = 99;
+        for (const kd of KNOWN_DOMAINS) {
+            const dist = levenshtein(d, kd);
+            if (dist < bestDist) {
+                bestDist = dist;
+                best = kd;
+            }
+        }
+        if (bestDist <= 2 && best !== d) {
+            return { corrected: best, reason: `Corrected to popular domain "${best}"` };
+        }
+
+        return {};
+    };
+
+    // Form Hook with validation
+    const form = useForm<FormValuesType>({
         initialValues: {
             domain: "",
             delay: 10,
@@ -66,21 +229,52 @@ const DNSMap = () => {
             csvResultsFile: "",
             ipsToIgnore: "",
         },
+        validate: {
+            domain: (value) => {
+                const raw = value ?? "";
+                const s = sanitiseDomain(raw);
+
+                if (!s) return "Please enter a domain (e.g., example.com).";
+
+                if (!isValidDomainSyntax(s)) {
+                    const { corrected } = correctDomainIfObvious(s);
+                    if (corrected && isValidDomainSyntax(corrected)) {
+                        return null; // soft-pass; we'll set corrected on submit and stop
+                    }
+                    return "That doesn't look like a valid domain (e.g., deakin.edu.au, google.com).";
+                }
+                return null;
+            },
+            delay: (v) => (v !== undefined && v !== null && v < 0 ? "Delay must be 0 or greater." : null),
+            ipsToIgnore: (v) => {
+                if (!v) return null;
+                const ips = v
+                    .split(",")
+                    .map((x) => x.trim())
+                    .filter(Boolean);
+                if (ips.length > 5) return "Maximum 5 IPs allowed.";
+                const ipRegex = /^(25[0-5]|2[0-4]\d|[01]?\d?\d)(\.(25[0-5]|2[0-4]\d|[01]?\d?\d)){3}$/;
+                for (const ip of ips) {
+                    if (!ipRegex.test(ip)) return `Invalid IP address: ${ip}`;
+                }
+                return null;
+            },
+        },
     });
-    // Check if the command is available and set the state variables accordingly.
+
+    // Command availability + disclaimer timer
     useEffect(() => {
-        // Check if the command is available and set the state variables accordingly.
         checkAllCommandsAvailability(dependencies)
             .then((isAvailable) => {
-                setIsCommandAvailable(isAvailable); // Set the command availability state
-                setOpened(!isAvailable); // Set the modal state to opened if the command is not available
-                setLoadingModal(false); // Set loading to false after the check is done
+                setIsCommandAvailable(isAvailable);
+                setOpened(!isAvailable);
+                setLoadingModal(false);
             })
             .catch((error) => {
                 console.error("An error occurred:", error);
-                setLoadingModal(false); // Also set loading to false in case of error
+                setLoadingModal(false);
             });
-        // Set timeout to remove alert after 5 seconds on load.
+
         alertTimeout.current = setTimeout(() => {
             setShowAlert(false);
         }, 5000);
@@ -102,24 +296,12 @@ const DNSMap = () => {
         }, 5000);
     };
 
-    /**
-     * handleProcessData: Callback to handle and append new data from the child process to the output.
-     * It updates the state by appending the new data received to the existing output.
-     *
-     * @param {string} data - The data received from the child process.
-     */
+    // Append new data to output
     const handleProcessData = useCallback((data: string) => {
-        setOutput((prevOutput) => prevOutput + "\n" + data); // Append new data to the previous output.
+        setOutput((prevOutput) => (prevOutput ? prevOutput + "\n" + data : data));
     }, []);
 
-    /**
-     * handleProcessTermination: Callback to handle the termination of the child process.
-     * Once the process termination is handled, it clears the process PID reference and
-     * deactivates the loading overlay.
-     * @param {object} param0 - An object containing information about the process termination.
-     * @param {number} param0.code - The exit code of the terminated process.
-     * @param {number} param0.signal - The signal code indicating how the process was terminated.
-     */
+    // Process termination handler
     const handleProcessTermination = useCallback(
         ({ code, signal }: { code: number; signal: number }) => {
             if (code === 0) {
@@ -129,63 +311,106 @@ const DNSMap = () => {
             } else {
                 handleProcessData(`\nProcess terminated with exit code: ${code} and signal code: ${signal}`);
             }
-            // Clear the child process pid reference
             setPid("");
-            // Cancel the Loading Overlay
             setLoading(false);
-
-            // Allow Saving as the output is finalised
             setAllowSave(true);
             setHasSaved(false);
         },
-        [handleProcessData] // Dependency on the handleProcessData callback
+        [handleProcessData]
     );
 
-    /**
-     * onSubmit: Handler function that is triggered when the form is submitted.
-     * It prepares the arguments and initiates the execution of the `dnsmap` command.
-     * Upon successful execution, it updates the state with the process PID and output.
-     * If an error occurs during the command execution, it updates the output with the error message.
-     * @param {FormValues} values - An object containing the form input values.
-     */
-
-    // Actions taken after saving the output
+    // Saving complete
     const handleSaveComplete = () => {
-        // Indicating that the file has saved which is passed
-        // back into SaveOutputToTextFile to inform the user
         setHasSaved(true);
         setAllowSave(false);
     };
 
-    const onSubmit = async (values: FormValuesType) => {
-        // Disallow saving until the tool's execution is complete
-        setAllowSave(false);
-
-        setLoading(true);
-        const args = [values.domain, "-d", `${values.delay}`];
-
-        values.wordlistPath ? args.push(`-w`, values.wordlistPath) : undefined;
-
-        values.csvResultsFile ? args.push(`-c`, values.csvResultsFile) : undefined;
-
-        values.ipsToIgnore ? args.push(`-i`, values.ipsToIgnore) : undefined;
-
-        const filteredArgs = args.filter((arg) => arg !== "");
-        CommandHelper.runCommandGetPidAndOutput("dnsmap", filteredArgs, handleProcessData, handleProcessTermination)
-            .then(({ pid, output }) => {
-                setPid(pid);
-                setOutput(output);
-            })
-            .catch((error) => {
-                setLoading(false);
-                setOutput(`Error: ${error.message}`);
-            });
-    };
     const clearOutput = useCallback(() => {
         setOutput("");
         setHasSaved(false);
         setAllowSave(false);
-    }, [setOutput]);
+    }, []);
+
+    /**
+     * onSubmit with "stop after autocorrect":
+     * - If we autocorrect, we set the corrected value, show yellow note, and RETURN (no run).
+     * - Only run dnsmap when no correction occurred in this submit.
+     */
+    const onSubmit = async (values: FormValuesType) => {
+        setErrorMsg(null);
+        setCorrectionMsg(null);
+
+        const rawDomain = values.domain ?? "";
+        const sanitised = sanitiseDomain(rawDomain);
+
+        const tryAutocorrect = () => {
+            const { corrected, reason } = correctDomainIfObvious(sanitised);
+            if (corrected && isValidDomainSyntax(corrected)) {
+                form.setFieldValue("domain", corrected);
+                setCorrectionMsg(`Auto-corrected domain: "${sanitised}" → "${corrected}". ${reason ?? ""}`);
+                return true;
+            }
+            return false;
+        };
+
+        // Invalid syntax → attempt correction then stop; else error
+        if (!isValidDomainSyntax(sanitised)) {
+            if (tryAutocorrect()) return;
+            setErrorMsg(
+                `Invalid domain "${rawDomain}". Please enter a valid domain like "example.com" or "deakin.edu.au".`
+            );
+            return;
+        }
+
+        // Valid syntax → maybe fix trivial typo; if corrected, stop this submit
+        {
+            const { corrected, reason } = correctDomainIfObvious(sanitised);
+            if (corrected && corrected !== sanitised && isValidDomainSyntax(corrected)) {
+                form.setFieldValue("domain", corrected);
+                setCorrectionMsg(`Auto-corrected domain: "${sanitised}" → "${corrected}". ${reason ?? ""}`);
+                return;
+            } else if (sanitised !== rawDomain) {
+                // normalise (strip protocol/paths). This isn't a semantic correction; allow run.
+                form.setFieldValue("domain", sanitised);
+            }
+        }
+
+        // Final guard
+        const finalDomain = sanitiseDomain(form.values.domain);
+        if (!isValidDomainSyntax(finalDomain)) {
+            setErrorMsg(`Invalid domain "${form.values.domain}". Please enter a valid domain like "example.com".`);
+            return;
+        }
+
+        // Build args & run
+        setAllowSave(false);
+        setLoading(true);
+        setOutput("");
+
+        const args: string[] = [finalDomain, "-d", String(values.delay ?? 10)];
+        if (values.wordlistPath) args.push("-w", values.wordlistPath);
+        if (values.csvResultsFile) args.push("-c", values.csvResultsFile);
+        if (values.ipsToIgnore) {
+            const ips = values.ipsToIgnore
+                .split(",")
+                .map((x) => x.trim())
+                .filter(Boolean)
+                .slice(0, 5);
+            if (ips.length > 0) args.push("-i", ips.join(","));
+        }
+
+        const filteredArgs = args.filter((a) => a !== "");
+
+        CommandHelper.runCommandGetPidAndOutput("dnsmap", filteredArgs, handleProcessData, handleProcessTermination)
+            .then(({ pid, output }) => {
+                setPid(pid);
+                if (output) setOutput(output);
+            })
+            .catch((error: any) => {
+                setLoading(false);
+                setOutput(`Error: ${error?.message ?? String(error)}`);
+            });
+    };
 
     return (
         <RenderComponent
@@ -201,10 +426,12 @@ const DNSMap = () => {
                     setOpened={setOpened}
                     feature_description={description_userguide}
                     dependencies={dependencies}
-                ></InstallationModal>
+                />
             )}
+
             <form onSubmit={form.onSubmit(onSubmit)}>
                 {LoadingOverlayAndCancelButton(loading, Pid)}
+
                 <Stack>
                     <Group position="right">
                         {!showAlert && (
@@ -213,12 +440,26 @@ const DNSMap = () => {
                             </Button>
                         )}
                     </Group>
+
                     {showAlert && (
                         <Alert title="Warning: Potential Risks" color="red">
                             This tool is used to perform DNS enumeration, use with caution and only on targets you own
                             or have explicit permission to test.
                         </Alert>
                     )}
+
+                    {correctionMsg && (
+                        <Alert title="Note" color="yellow">
+                            {correctionMsg}
+                        </Alert>
+                    )}
+
+                    {errorMsg && (
+                        <Alert title="Invalid domain" color="red">
+                            {errorMsg}
+                        </Alert>
+                    )}
+
                     <Switch
                         size="md"
                         label="Advanced Mode"
@@ -226,31 +467,47 @@ const DNSMap = () => {
                         onChange={(e) => setCheckedAdvanced(e.currentTarget.checked)}
                     />
 
-                    <TextInput label={"Domain"} required {...form.getInputProps("domain")} />
+                    <TextInput
+                        label={"Domain"}
+                        required
+                        placeholder="example.com"
+                        {...form.getInputProps("domain")}
+                        onBlur={(e) => {
+                            const s = sanitiseDomain(e.currentTarget.value || "");
+                            if (s && s !== e.currentTarget.value) form.setFieldValue("domain", s);
+                        }}
+                    />
 
                     <TextInput
-                        label={"Random delay between requests (default 10)(milliseconds)"}
+                        label={"Random delay between requests (default 10) (milliseconds)"}
                         type="number"
                         {...form.getInputProps("delay")}
                     />
+
                     {checkedAdvanced && (
                         <>
                             <TextInput
                                 label={"Path to external wordlist file"}
+                                placeholder="/usr/share/wordlists/dnsmap.txt"
                                 {...form.getInputProps("wordlistPath")}
                             />
                             <TextInput
                                 label={"CSV results file name (optional)"}
+                                placeholder="results.csv"
                                 {...form.getInputProps("csvResultsFile")}
                             />
                             <TextInput
                                 label={"IP addresses to ignore (comma-separated, up to 5 IPs)"}
+                                placeholder="1.2.3.4, 5.6.7.8"
                                 {...form.getInputProps("ipsToIgnore")}
                             />
                         </>
                     )}
+
                     {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
+
                     <Button type={"submit"}>Start Mapping</Button>
+
                     <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
                 </Stack>
             </form>

--- a/src/components/Netcat/Netcat.tsx
+++ b/src/components/Netcat/Netcat.tsx
@@ -25,7 +25,7 @@ interface FormValuesType {
    Validators (domains / IPv4 / IPv6 + ports)
    ------------------------- */
 
-// Domain: must include at least one dot; labels 1–63; total <=253; no leading/trailing hyphen .
+// Domain: must include at least one dot; labels 1–63; total <=253; no leading/trailing hyphen.
 const isValidDomain = (host: string) => {
     if (!host) return false;
     const s = host.trim();

--- a/src/components/Netcat/Netcat.tsx
+++ b/src/components/Netcat/Netcat.tsx
@@ -25,7 +25,7 @@ interface FormValuesType {
    Validators (domains / IPv4 / IPv6 + ports)
    ------------------------- */
 
-// Domain: must include at least one dot; labels 1–63; total <=253; no leading/trailing hyphen.
+// Domain: must include at least one dot; labels 1–63; total <=253; no leading/trailing hyphen .
 const isValidDomain = (host: string) => {
     if (!host) return false;
     const s = host.trim();

--- a/src/components/Netcat/Netcat.tsx
+++ b/src/components/Netcat/Netcat.tsx
@@ -1,4 +1,4 @@
-import { Button, NativeSelect, Stack, TextInput, Stepper, Switch, Grid } from "@mantine/core";
+import { Button, NativeSelect, Stack, TextInput, Stepper, Switch, Group, Badge, Text } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useCallback, useState, useEffect } from "react";
 import { CommandHelper } from "../../utils/CommandHelper";
@@ -21,36 +21,99 @@ interface FormValuesType {
     filePath: string;
 }
 
+/* -------------------------
+   Validators (domains / IPv4 / IPv6 + ports)
+   ------------------------- */
+
+// Domain: must include at least one dot; labels 1–63; total <=253; no leading/trailing hyphen.
+const isValidDomain = (host: string) => {
+    if (!host) return false;
+    const s = host.trim();
+    // reject schemes or paths
+    if (/^[a-z]+:\/\//i.test(s) || /[\/?#]/.test(s)) return false;
+    // localhost is not a domain with a dot; allow it only if you want — here we reject it for WHOIS-like checks
+    const re = /^(?=.{1,253}$)(?!-)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i;
+    return re.test(s);
+};
+
+// IPv4: dotted-quad, each 0–255
+const isValidIPv4 = (ip: string) => {
+    if (!ip) return false;
+    const m = ip.trim().match(/^(\d{1,3}\.){3}\d{1,3}$/);
+    if (!m) return false;
+    return ip.split(".").every((o) => {
+        const n = Number(o);
+        return o === String(n) && n >= 0 && n <= 255;
+    });
+};
+
+// IPv6: reasonably complete regex covering full, shortened, and with embedded IPv4
+const isValidIPv6 = (ip: string) => {
+    if (!ip) return false;
+    const s = ip.trim();
+    const re = new RegExp(
+        "^(" +
+            "([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|" + // 1:2:3:4:5:6:7:8
+            "([0-9A-Fa-f]{1,4}:){1,7}:|" + // 1:: 1:2:3:4:5:6:7::
+            ":[0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,6}|" + // ::2  ::2:3  ... ::2:3:4:5:6:7
+            "([0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}|" + // 1:2:3:4:5:6::8
+            "([0-9A-Fa-f]{1,4}:){1,5}(:[0-9A-Fa-f]{1,4}){1,2}|" + // 1:2:3:4:5::7:8
+            "([0-9A-Fa-f]{1,4}:){1,4}(:[0-9A-Fa-f]{1,4}){1,3}|" + // 1:2:3:4::6:7:8
+            "([0-9A-Fa-f]{1,4}:){1,3}(:[0-9A-Fa-f]{1,4}){1,4}|" + // 1:2:3::5:6:7:8
+            "([0-9A-Fa-f]{1,4}:){1,2}(:[0-9A-Fa-f]{1,4}){1,5}|" + // 1:2::4:5:6:7:8
+            "[0-9A-Fa-f]{1,4}:(:[0-9A-Fa-f]{1,4}){1,6}|" + // 1::3:4:5:6:7:8
+            ":(:[0-9A-Fa-f]{1,4}){1,7}|" + // ::2:3:4:5:6:7:8  or ::8
+            // IPv6 with embedded IPv4
+            "([0-9A-Fa-f]{1,4}:){6}(\\d{1,3}\\.){3}\\d{1,3}|" +
+            "([0-9A-Fa-f]{1,4}:){0,5}:[0-9A-Fa-f]{1,4}:(\\d{1,3}\\.){3}\\d{1,3}|" +
+            "::(ffff(?::0{1,4}){0,1}:)?(\\d{1,3}\\.){3}\\d{1,3}" +
+            ")$"
+    );
+    if (!re.test(s)) return false;
+    // If embedded IPv4 exists, ensure each quad <=255
+    const v4 = s.match(/(\d{1,3}\.){3}\d{1,3}$/);
+    if (v4) return isValidIPv4(v4[0]);
+    return true;
+};
+
+const isHost = (v: string) => isValidDomain(v) || isValidIPv4(v) || isValidIPv6(v);
+
+const isValidPort = (p: string) => {
+    if (!p) return false;
+    const s = p.trim();
+    if (!/^\d+$/.test(s)) return false;
+    const n = Number(s);
+    return n >= 1 && n <= 65535;
+};
+
+/* -------------------------
+   Component
+   ------------------------- */
 const NetcatTool = () => {
     // Component State Variables
-    const [output, setOutput] = useState(""); // State variable to store the output of the command execution.
-    const [pid, setPid] = useState(""); // State variable to store the process ID of the command execution.
-    const [isCommandAvailable, setIsCommandAvailable] = useState(false); // State variable to check if the command is available.
-    const [loading, setLoading] = useState(false); // State variable to indicate loading state.
-    const [allowSave, setAllowSave] = useState(false); // State variable to allow saving the output to a file
-    const [hasSaved, setHasSaved] = useState(false); // State variable to indicate if the output has been saved
-    const [checkedVerboseMode, setCheckedVerboseMode] = useState(false); // State variable to indicate whether the verbose mode is enabled.
-    const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state of the modal.
-    const [opened, setOpened] = useState(!isCommandAvailable); // State variable that indicates if the modal is opened.
-    const [fileNames, setFileNames] = useState<string[]>([]); // State variable to store the file names.
-    const [active, setActive] = useState(0); // State variable for the Stepper's active step.
+    const [output, setOutput] = useState("");
+    const [pid, setPid] = useState("");
+    const [isCommandAvailable, setIsCommandAvailable] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [allowSave, setAllowSave] = useState(false);
+    const [hasSaved, setHasSaved] = useState(false);
+    const [checkedVerboseMode, setCheckedVerboseMode] = useState(false);
+    const [loadingModal, setLoadingModal] = useState(true);
+    const [opened, setOpened] = useState(!isCommandAvailable);
+    const [fileNames, setFileNames] = useState<string[]>([]);
+    const [active, setActive] = useState(0);
 
     // Component Constants
-    const title = "Netcat"; // Title of the component.
+    const title = "Netcat";
     const description =
-        "A simple Unix utility which reads and writes data across network connections using TCP or UDP protocol."; // Description of the component.
+        "A simple Unix utility which reads and writes data across network connections using TCP or UDP protocol.";
     const steps =
         "Step 1: Select the Netcat option.\n" +
         "Step 2: Provide the required inputs based on the selected option.\n" +
         "Step 3: Run the Netcat command and review results.";
-    "Note 1: If you want to listen for connections for chat or reverse shell choose the listen option and provide a port number.\n" +
-        "Note 2: If you want to scan for ports, provide an IP address and a port range.\n" +
-        "Note 3: If you want to send/receive a file, provide the destination IP address, port number, and file name.Using the sending/receiving file option might seem like it is not working, but it is working. \n" +
-        "Note 4: If you want to port scan a domain, provide domain name and a port number.You should only use website port scan on a domain that you own. \n\n" +
-        "Ensure both machines are properly configured and connected to the same network or through an accessible route (such as a VPN, or through valid public IP addresses) to complete the file transfer.\n";
-    const sourceLink = "https://www.kali.org/tools/netcat/"; // Link to the source code
-    const tutorial = "https://docs.google.com/document/d/1NQ-hy8NBuTTUJzHebST5UF42JPjJ3yfIvNgWbM7FPLE/edit?usp=sharing"; // Link to the official documentation/tutorial.
-    const dependencies = ["nc"]; // Contains the dependencies required by the component
+    const sourceLink = "https://www.kali.org/tools/netcat/";
+    const tutorial = "https://docs.google.com/document/d/1NQ-hy8NBuTTUJzHebST5UF42JPjJ3yfIvNgWbM7FPLE/edit?usp=sharing";
+    const dependencies = ["nc"];
 
     // Form hook to handle form input.
     const form = useForm<FormValuesType>({
@@ -61,9 +124,14 @@ const NetcatTool = () => {
             websiteUrl: "",
             filePath: "",
         },
+        validateInputOnChange: true,
+        validateInputOnBlur: true,
+        validate: {
+            netcatOptions: (v) => (v ? null : "Please select an option"),
+        },
     });
 
-    // Check if the command is available and set the state variables accordingly.
+    // Check command availability
     useEffect(() => {
         checkAllCommandsAvailability(dependencies)
             .then((isAvailable) => {
@@ -77,23 +145,10 @@ const NetcatTool = () => {
             });
     }, []);
 
-    /**
-     * handleProcessData: Callback to handle and append new data from the child process to the output.
-     * It updates the state by appending the new data received to the existing output.
-     * @param {string} data - The data received from the child process.
-     */
     const handleProcessData = useCallback((data: string) => {
-        setOutput((prevOutput) => prevOutput + "\n" + data); // Append new data to the previous output.
+        setOutput((prevOutput) => prevOutput + "\n" + data);
     }, []);
 
-    /**
-     * handleProcessTermination: Callback to handle the termination of the child process.
-     * Once the process termination is handled, it clears the process PID reference and
-     * deactivates the loading overlay.
-     * @param {object} param - An object containing information about the process termination.
-     * @param {number} param.code - The exit code of the terminated process.
-     * @param {number} param.signal - The signal code indicating how the process was terminated.
-     */
     const handleProcessTermination = useCallback(
         ({ code, signal }: { code: number; signal: number }) => {
             console.log("handleProcessTermination called with code:", code, "signal:", signal);
@@ -105,7 +160,7 @@ const NetcatTool = () => {
                 handleProcessData(`\nProcess terminated with exit code: ${code} and signal code: ${signal}`);
             }
 
-            setPid(""); // Clear the PID reference.
+            setPid("");
             setLoading(false);
             setAllowSave(true);
             setHasSaved(false);
@@ -114,21 +169,77 @@ const NetcatTool = () => {
     );
 
     /**
-     * Handles the submission of the form and executes the appropriate netcat command based on the selected options.
-     *
-     * @param {FormValuesType} values - The values from the form submission.
-     * @returns {Promise<void>} - A promise that resolves when the command execution is complete.
+     * Per-option validation (now: domain/IPv4/IPv6 for host-like inputs).
+     * This only guards navigation/submit; command behavior is unchanged.
+     */
+    const validateForOption = (values: FormValuesType) => {
+        const errors: Partial<Record<keyof FormValuesType, string>> = {};
+        const opt = values.netcatOptions;
+
+        if (!opt) errors.netcatOptions = "Please select an option";
+
+        if (opt === "Listen") {
+            if (!values.portNumber) errors.portNumber = "Port is required";
+            else if (!isValidPort(values.portNumber)) errors.portNumber = "Enter a valid port (1–65535)";
+        }
+
+        if (opt === "Connect") {
+            if (!values.ipAddress) errors.ipAddress = "Host is required";
+            else if (!(isValidIPv4(values.ipAddress) || isValidIPv6(values.ipAddress)))
+                errors.ipAddress = "Enter a valid IPv4 or IPv6";
+            if (!values.portNumber) errors.portNumber = "Port is required";
+            else if (!isValidPort(values.portNumber)) errors.portNumber = "Enter a valid port (1–65535)";
+        }
+
+        if (opt === "Port Scan") {
+            if (!values.ipAddress) errors.ipAddress = "Host is required";
+            else if (!isHost(values.ipAddress)) errors.ipAddress = "Enter a valid domain or IP";
+            if (!values.portNumber) errors.portNumber = "Port/Range is required";
+            // (range parsing intentionally left alone to avoid runtime changes)
+        }
+
+        if (opt === "Website Port Scan") {
+            if (!values.portNumber) errors.portNumber = "Port/Range is required";
+            if (!values.websiteUrl) errors.websiteUrl = "Host is required";
+            else if (!isHost(values.websiteUrl)) errors.websiteUrl = "Enter a valid domain or IP";
+        }
+
+        if (opt === "Send File") {
+            if (!values.ipAddress) errors.ipAddress = "Host is required";
+            else if (!(isValidIPv4(values.ipAddress) || isValidIPv6(values.ipAddress)))
+                errors.ipAddress = "Enter a valid IPv4 or IPv6";
+            if (!values.portNumber) errors.portNumber = "Port is required";
+            else if (!isValidPort(values.portNumber)) errors.portNumber = "Enter a valid port (1–65535)";
+            if (fileNames.length === 0) errors.filePath = "Please select a file to send";
+        }
+
+        if (opt === "Receive File") {
+            if (!values.portNumber) errors.portNumber = "Port is required";
+            else if (!isValidPort(values.portNumber)) errors.portNumber = "Enter a valid port (1–65535)";
+            if (!values.filePath) errors.filePath = "Output file path is required";
+        }
+
+        form.setErrors(errors);
+        return Object.keys(errors).length === 0;
+    };
+
+    /**
+     * Submit: unchanged command behavior; just blocked if inputs invalid.
      */
     const onSubmit = async (values: FormValuesType) => {
+        if (!validateForOption(values)) {
+            setLoading(false);
+            return;
+        }
+
         setLoading(true);
         setAllowSave(false);
 
-        let command = "nc"; // Default command
+        let command = "nc";
         let args: string[] = [];
         const verboseFlag = checkedVerboseMode ? "-vn" : "-n";
         const verboseFlagWithSpaceAndDash = checkedVerboseMode ? " -v" : "";
 
-        // Handle different netcat operations
         switch (values.netcatOptions) {
             case "Listen":
                 args = ["-l", verboseFlag, "-w", "60", "-p", values.portNumber];
@@ -143,7 +254,11 @@ const NetcatTool = () => {
                 args = ["-z", verboseFlag, "-w", "5", values.websiteUrl, values.portNumber];
                 break;
             case "Send File":
-                // Use bash to handle the redirection - note use of verboseFlagWithSpaceAndDash
+                if (fileNames.length === 0) {
+                    form.setFieldError("filePath", "Please select a file to send");
+                    setLoading(false);
+                    return;
+                }
                 command = "bash";
                 args = [
                     "-c",
@@ -151,7 +266,6 @@ const NetcatTool = () => {
                 ];
                 break;
             case "Receive File":
-                // Use bash to handle the redirection - note use of verboseFlagWithSpaceAndDash
                 command = "bash";
                 args = [
                     "-c",
@@ -180,44 +294,48 @@ const NetcatTool = () => {
                 handleProcessData(
                     "\nNote: This operation may keep running. The loading overlay will stop in 10 seconds."
                 );
-
-                // Safety timeout to ensure loading overlay stops
                 setTimeout(() => {
                     console.log("Safety timeout triggered - stopping loading overlay");
                     setLoading(false);
                     setAllowSave(true);
-                }, 10000); // 10 seconds
+                }, 10000);
             }
         } catch (error: any) {
             setOutput(`Error: ${error.message}`);
-            setLoading(false); //Stop Loading state
+            setLoading(false);
             setAllowSave(true);
         }
     };
 
-    /**
-     * clearOutput: Callback function to clear the console output.
-     * It resets the state variable holding the output, thereby clearing the display.
-     */
     const clearOutput = useCallback(() => {
         setOutput("");
         setHasSaved(false);
         setAllowSave(false);
     }, []);
 
-    /**
-     * handleSaveComplete: Recognises that the output file has been saved.
-     * Passes the saved status back to SaveOutputToTextFile_v2
-     */
     const handleSaveComplete = () => {
         setHasSaved(true);
         setAllowSave(false);
     };
 
-    // Function to handle the next step in the Stepper.
-    const nextStep = () => setActive((current) => (current < 2 ? current + 1 : current));
+    // Guarded stepper next that enforces per-step validation
+    const guardedNextStep = () => {
+        if (active === 0) {
+            if (!form.values.netcatOptions) {
+                form.setFieldError("netcatOptions", "Please select an option");
+                return;
+            }
+            setActive(1);
+            return;
+        }
+        if (active === 1) {
+            if (!validateForOption(form.values)) return;
+            setActive(2);
+            return;
+        }
+        if (active < 2) setActive((c) => c + 1);
+    };
 
-    // Function to handle the previous step in the Stepper.
     const prevStep = () => setActive((current) => (current > 0 ? current - 1 : current));
 
     return (
@@ -238,11 +356,19 @@ const NetcatTool = () => {
             )}
             <form onSubmit={form.onSubmit(onSubmit)}>
                 {LoadingOverlayAndCancelButtonPkexec(loading, pid, handleProcessData, handleProcessTermination)}
-                <Stepper active={active} onStepClick={setActive} breakpoint="sm">
+                <Stepper
+                    active={active}
+                    onStepClick={(s) => {
+                        if (s <= active) return setActive(s);
+                        if (active === 0 && form.values.netcatOptions) return setActive(1);
+                        if (active === 1 && validateForOption(form.values)) return setActive(2);
+                    }}
+                    breakpoint="sm"
+                >
                     <Stepper.Step label="Select Option">
                         <NativeSelect
-                            value={form.values.netcatOptions} // Bind to the form's netcatOptions field
-                            onChange={(e) => form.setFieldValue("netcatOptions", e.target.value)} // Update the form's netcatOptions field
+                            value={form.values.netcatOptions}
+                            onChange={(e) => form.setFieldValue("netcatOptions", e.target.value)}
                             title={"Netcat option"}
                             data={[
                                 { value: "", label: "Pick a Netcat option", disabled: true },
@@ -254,11 +380,12 @@ const NetcatTool = () => {
                                 { value: "Website Port Scan", label: "Website Port Scan" },
                             ]}
                             required
+                            error={form.errors.netcatOptions}
                         />
                     </Stepper.Step>
+
                     <Stepper.Step label="Provide Inputs">
                         <Stack>
-                            {/* Verbose Mode Toggle */}
                             <Switch
                                 label="Enable Verbose Mode"
                                 checked={checkedVerboseMode}
@@ -266,56 +393,131 @@ const NetcatTool = () => {
                             />
 
                             {form.values.netcatOptions === "Listen" && (
-                                <TextInput label={"Port number"} required {...form.getInputProps("portNumber")} />
+                                <TextInput
+                                    label={"Port number"}
+                                    required
+                                    {...form.getInputProps("portNumber")}
+                                    error={form.errors.portNumber}
+                                />
                             )}
+
                             {form.values.netcatOptions === "Connect" && (
                                 <>
-                                    <TextInput label={"IP address"} required {...form.getInputProps("ipAddress")} />
-                                    <TextInput label={"Port number"} required {...form.getInputProps("portNumber")} />
-                                </>
-                            )}
-                            {form.values.netcatOptions === "Port Scan" && (
-                                <>
-                                    <TextInput label={"IP address"} required {...form.getInputProps("ipAddress")} />
                                     <TextInput
-                                        label={"Port number/Port range"}
+                                        label={"Host (IPv4 / IPv6)"}
+                                        required
+                                        {...form.getInputProps("ipAddress")}
+                                        error={form.errors.ipAddress}
+                                        placeholder="93.184.216.34 or 2001:db8::1"
+                                    />
+                                    <TextInput
+                                        label={"Port number"}
                                         required
                                         {...form.getInputProps("portNumber")}
+                                        error={form.errors.portNumber}
                                     />
                                 </>
                             )}
+
+                            {form.values.netcatOptions === "Port Scan" && (
+                                <>
+                                    <TextInput
+                                        label={"Host (domain or IP)"}
+                                        required
+                                        {...form.getInputProps("ipAddress")}
+                                        error={form.errors.ipAddress}
+                                        placeholder="example.com / 93.184.216.34 / 2001:db8::1"
+                                    />
+                                    <TextInput
+                                        label={"Port number/Port range"}
+                                        required
+                                        placeholder="80 or 1-1024"
+                                        {...form.getInputProps("portNumber")}
+                                        error={form.errors.portNumber}
+                                    />
+                                </>
+                            )}
+
                             {form.values.netcatOptions === "Send File" && (
                                 <>
-                                    <TextInput label={"IP address"} required {...form.getInputProps("ipAddress")} />
-                                    <TextInput label={"Port number"} required {...form.getInputProps("portNumber")} />
+                                    <TextInput
+                                        label={"Host (IPv4 / IPv6)"}
+                                        required
+                                        {...form.getInputProps("ipAddress")}
+                                        error={form.errors.ipAddress}
+                                        placeholder="93.184.216.34 or 2001:db8::1"
+                                    />
+                                    <TextInput
+                                        label={"Port number"}
+                                        required
+                                        {...form.getInputProps("portNumber")}
+                                        error={form.errors.portNumber}
+                                    />
                                     <FilePicker
                                         fileNames={fileNames}
                                         setFileNames={setFileNames}
                                         multiple={false}
                                         componentName="Netcat"
                                         labelText="File"
-                                        placeholderText="Click to select file(s)"
+                                        placeholderText="Click to select file"
+                                    />
+                                    {fileNames.length > 0 ? (
+                                        <Group spacing="xs" style={{ marginTop: 8 }}>
+                                            <Text size="sm">Selected file:</Text>
+                                            {fileNames.map((n) => (
+                                                <Badge key={n} variant="outline">
+                                                    {n}
+                                                </Badge>
+                                            ))}
+                                        </Group>
+                                    ) : (
+                                        form.errors.filePath && (
+                                            <Text size="sm" color="red" style={{ marginTop: 8 }}>
+                                                {form.errors.filePath}
+                                            </Text>
+                                        )
+                                    )}
+                                </>
+                            )}
+
+                            {form.values.netcatOptions === "Receive File" && (
+                                <>
+                                    <TextInput
+                                        label={"Port number"}
+                                        required
+                                        {...form.getInputProps("portNumber")}
+                                        error={form.errors.portNumber}
+                                    />
+                                    <TextInput
+                                        label={"File path"}
+                                        required
+                                        {...form.getInputProps("filePath")}
+                                        error={form.errors.filePath}
                                     />
                                 </>
                             )}
-                            {form.values.netcatOptions === "Receive File" && (
-                                <>
-                                    <TextInput label={"Port number"} required {...form.getInputProps("portNumber")} />
-                                    <TextInput label={"File path"} required {...form.getInputProps("filePath")} />
-                                </>
-                            )}
+
                             {form.values.netcatOptions === "Website Port Scan" && (
                                 <>
                                     <TextInput
                                         label={"Port number/Port range"}
                                         required
+                                        placeholder="80 or 1-1024"
                                         {...form.getInputProps("portNumber")}
+                                        error={form.errors.portNumber}
                                     />
-                                    <TextInput label={"Domain name"} required {...form.getInputProps("websiteUrl")} />
+                                    <TextInput
+                                        label={"Host (domain or IP)"}
+                                        required
+                                        {...form.getInputProps("websiteUrl")}
+                                        error={form.errors.websiteUrl}
+                                        placeholder="example.com / 93.184.216.34 / 2001:db8::1"
+                                    />
                                 </>
                             )}
                         </Stack>
                     </Stepper.Step>
+
                     <Stepper.Step label="Run">
                         <Stack align="center" mt={20}>
                             <Button type="submit" disabled={loading} style={{ alignSelf: "center" }}>
@@ -325,15 +527,16 @@ const NetcatTool = () => {
                     </Stepper.Step>
                 </Stepper>
 
-                {/* Add navigation buttons */}
+                {/* Navigation buttons */}
                 <div style={{ marginTop: "20px", display: "flex", justifyContent: "space-between" }}>
                     <Button onClick={prevStep} disabled={active === 0}>
                         Previous
                     </Button>
-                    <Button onClick={nextStep} disabled={active === 2}>
+                    <Button onClick={guardedNextStep} disabled={active === 2}>
                         Next
                     </Button>
                 </div>
+
                 {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
                 <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
             </form>


### PR DESCRIPTION
Issue:
The DNSMap tool previously accepted invalid or misspelled domains (e.g., githuub.com) and still attempted to execute the scan. This caused the process to run indefinitely until manually terminated, creating confusion and wasted resources. (Related to Bug #1455)

What Changed:

- Added strict domain validation and sanitisation before execution.
- Implemented autocorrection for common typos (e.g., .con → .com, githuub.com → github.com).
- If a correction is made, the tool now:

1. Shows a yellow note with the correction.
2. Stops execution immediately instead of running with the wrong input.
3. Requires the user to re-submit with the corrected domain.

- Displays a red error message for invalid domains that cannot be corrected.
- Ensures no dnsmap process is spawned on bad input.

Why This Fix Matters:

1. Prevents unnecessary scans on invalid inputs.
2. Improves usability with clear feedback for the user.
3. Saves time and system resources by avoiding indefinite hangs.
4. Keeps behavior consistent with other toolkit tools (fail fast on bad input).

Testing Steps:

1. Open DNSMap in the toolkit.
2. Enter githuub.com → Tool suggests github.com, shows yellow note, does not start scan.
3. Enter goole.con → Tool corrects to google.com, shows yellow note, does not start scan.
4. Enter !!! → Tool rejects with red error.
5. Enter github.com (valid) → Tool runs normally.

Result:
Users only run DNSMap on valid/corrected domains. Wrong domains are blocked with clear UI feedback.