### PR TITLE
Fix: Enum4Linux multiple options tokenization and parameter validation

### DIFF
--- a/src/components/Enum4Linux/Enum4Linux.tsx
+++ b/src/components/Enum4Linux/Enum4Linux.tsx
@@ -69,30 +69,30 @@ const Enum4Linux = () => {
     // Valid enum4linux parameters for validation
     const validParams = [
         // Basic enumeration options
-        'U', // get userlist
-        'M', // get machine list
-        'S', // get sharelist  
-        'P', // get password policy information
-        'G', // get group and member list
-        'd', // be detailed, applies to -U and -S
-        'u', // specify username to use
-        'p', // specify password to use
-        
+        "U", // get userlist
+        "M", // get machine list
+        "S", // get sharelist
+        "P", // get password policy information
+        "G", // get group and member list
+        "d", // be detailed, applies to -U and -S
+        "u", // specify username to use
+        "p", // specify password to use
+
         // Additional options
-        'a', // Do all simple enumeration (-U -S -G -P -r -o -n -i)
-        'h', // Display help message and exit
-        'r', // enumerate users via RID cycling
-        'R', // RID ranges to enumerate (default: 500-550,1000-1050, implies -r)
-        'K', // Keep searching RIDs until n consecutive RIDs don't correspond to a username
-        'l', // Get some (limited) info via LDAP 389/TCP (for DCs only)
-        's', // brute force guessing for share names
-        'k', // User(s) that exists on remote system
-        'o', // Get OS information
-        'i', // Get printer information
-        'w', // Specify workgroup manually
-        'n', // Do an nmblookup (similar to nbtstat)
-        'v', // Verbose. Shows full commands being run
-        'A'  // Aggressive. Do write checks on shares etc
+        "a", // Do all simple enumeration (-U -S -G -P -r -o -n -i)
+        "h", // Display help message and exit
+        "r", // enumerate users via RID cycling
+        "R", // RID ranges to enumerate (default: 500-550,1000-1050, implies -r)
+        "K", // Keep searching RIDs until n consecutive RIDs don't correspond to a username
+        "l", // Get some (limited) info via LDAP 389/TCP (for DCs only)
+        "s", // brute force guessing for share names
+        "k", // User(s) that exists on remote system
+        "o", // Get OS information
+        "i", // Get printer information
+        "w", // Specify workgroup manually
+        "n", // Do an nmblookup (similar to nbtstat)
+        "v", // Verbose. Shows full commands being run
+        "A", // Aggressive. Do write checks on shares etc
     ];
 
     const form = useForm({
@@ -106,7 +106,7 @@ const Enum4Linux = () => {
         validate: {
             ipAddress: (value) => {
                 const ipRegex = /^(\d{1,3}\.){3}\d{1,3}$|^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+$/;
-                return !ipRegex.test(value) ? 'Please enter a valid IP address or hostname' : null;
+                return !ipRegex.test(value) ? "Please enter a valid IP address or hostname" : null;
             },
         },
     });
@@ -150,8 +150,8 @@ const Enum4Linux = () => {
         }
 
         // Remove any existing dashes and spaces
-        const cleanParam = param.replace(/^-+/, '').trim();
-        
+        const cleanParam = param.replace(/^-+/, "").trim();
+
         // Check for multiple parameters (like "u username p password")
         const parts = cleanParam.split(/\s+/);
         let formattedParams = [];
@@ -159,7 +159,7 @@ const Enum4Linux = () => {
 
         for (let i = 0; i < parts.length; i++) {
             const part = parts[i];
-            
+
             // If it's a single letter parameter
             if (part.length === 1 && validParams.includes(part)) {
                 formattedParams.push(`-${part}`);
@@ -180,14 +180,14 @@ const Enum4Linux = () => {
             return {
                 isValid: false,
                 formatted: "",
-                error: `Invalid parameter(s): ${invalidParams.join(', ')}. Valid options: ${validParams.join(', ')}`
+                error: `Invalid parameter(s): ${invalidParams.join(", ")}. Valid options: ${validParams.join(", ")}`,
             };
         }
 
         return {
             isValid: true,
-            formatted: formattedParams.join(' '),
-            error: ""
+            formatted: formattedParams.join(" "),
+            error: "",
         };
     };
 
@@ -235,7 +235,7 @@ const Enum4Linux = () => {
 
         setLoading(true);
         setAllowSave(false);
-        
+
         // Build options string
         let options = `-${selectedOption}`;
         if (osinfo) options = options.concat(" -o");
@@ -310,7 +310,7 @@ const Enum4Linux = () => {
                             own or have explicit permission to test.
                         </Alert>
                     )}
-                    
+
                     {paramError && (
                         <Alert title="Parameter Error" color="yellow">
                             {paramError}
@@ -372,7 +372,7 @@ const Enum4Linux = () => {
                             description="Valid options: U (userlist), S (sharelist), G (groups), P (password policy), d (detailed), v (verbose), r (RID cycling), etc."
                         />
                     </Tooltip>
-                    
+
                     {customMode && (
                         <>
                             <Tooltip
@@ -389,7 +389,7 @@ const Enum4Linux = () => {
                             </Tooltip>
                         </>
                     )}
-                    
+
                     {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
                     <Button type="submit">Start {title}</Button>
                     <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />

--- a/src/components/Enum4Linux/Enum4Linux.tsx
+++ b/src/components/Enum4Linux/Enum4Linux.tsx
@@ -38,21 +38,63 @@ const Enum4Linux = () => {
     const [selectedOption, setselectedOption] = useState("M");
     const [chatGPTResponse, setChatGPTResponse] = useState("");
     const [showAlert, setShowAlert] = useState(true);
-    const alertTimeout = useRef<NodeJS.Timeout | null>(null);
+    const [paramError, setParamError] = useState("");
+    const alertTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const dependencies = ["enum4linux"];
     const title = "Enum4Linux";
     const description = "Enum4linux is a tool used for enumerating information from Windows and Samba systems.";
     const steps =
+        "How to use Enum4Linux:\n\n" +
         "Step 1: Enter the IP address of the target.\n" +
-        "Step 2: Select the option you want for enumeration. Options for enumerating machines, users and shared directories.\n" +
-        "Step 3: Enter any additional parameters you want to add, like specific credentials.\n" +
-        "Step 4: Click the Start " +
-        title +
-        " button and view the output block to see the results. ";
-    const sourceLink = "https://www.kali.org/tools/enum4linux/"; // Link to the source code (or Kali Tools).
-    const tutorial = "https://docs.google.com/document/d/1F4F-CGdQoedHk3A4nSthafHocbhTwKZv8GnBCtghouQ/edit?usp=sharing"; // Link to the official documentation/tutorial.
+        "       E.g. 192.168.1.10\n\n" +
+        "Step 2: Select the main enumeration option (Machine List, User List, or Share List).\n" +
+        "       These correspond to -M, -U, and -S flags respectively.\n\n" +
+        "Step 3: Enter additional parameters as needed:\n" +
+        "       • u username p password - for authentication\n" +
+        "       • d v - for detailed verbose output\n" +
+        "       • r - for RID cycling to enumerate users\n" +
+        "       • G P - for groups and password policy\n" +
+        "       • a - for all simple enumeration\n\n" +
+        "Step 4: Enable 'Custom Configuration' for advanced options like:\n" +
+        "       • R 500-1000 - custom RID range\n" +
+        "       • A - aggressive enumeration\n" +
+        "       • s filename - share name bruteforcing\n\n" +
+        "Step 5: Toggle 'Include OS Information' to add -o flag for OS details.\n\n" +
+        "Step 6: Click 'Start Enum4Linux' and view results in the output section.";
+    const sourceLink = "https://www.kali.org/tools/enum4linux/";
+    const tutorial = "https://docs.google.com/document/d/1F4F-CGdQoedHk3A4nSthafHocbhTwKZv8GnBCtghouQ/edit?usp=sharing";
     const [osinfo, setInfo] = useState(false);
+
+    // Valid enum4linux parameters for validation
+    const validParams = [
+        // Basic enumeration options
+        'U', // get userlist
+        'M', // get machine list
+        'S', // get sharelist  
+        'P', // get password policy information
+        'G', // get group and member list
+        'd', // be detailed, applies to -U and -S
+        'u', // specify username to use
+        'p', // specify password to use
+        
+        // Additional options
+        'a', // Do all simple enumeration (-U -S -G -P -r -o -n -i)
+        'h', // Display help message and exit
+        'r', // enumerate users via RID cycling
+        'R', // RID ranges to enumerate (default: 500-550,1000-1050, implies -r)
+        'K', // Keep searching RIDs until n consecutive RIDs don't correspond to a username
+        'l', // Get some (limited) info via LDAP 389/TCP (for DCs only)
+        's', // brute force guessing for share names
+        'k', // User(s) that exists on remote system
+        'o', // Get OS information
+        'i', // Get printer information
+        'w', // Specify workgroup manually
+        'n', // Do an nmblookup (similar to nbtstat)
+        'v', // Verbose. Shows full commands being run
+        'A'  // Aggressive. Do write checks on shares etc
+    ];
+
     const form = useForm({
         initialValues: {
             ipAddress: "",
@@ -60,6 +102,12 @@ const Enum4Linux = () => {
             paramMain: "",
             argumentAlt: "",
             paramAlt: "",
+        },
+        validate: {
+            ipAddress: (value) => {
+                const ipRegex = /^(\d{1,3}\.){3}\d{1,3}$|^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+$/;
+                return !ipRegex.test(value) ? 'Please enter a valid IP address or hostname' : null;
+            },
         },
     });
 
@@ -74,7 +122,6 @@ const Enum4Linux = () => {
                 console.error("Error checking command availability:", error);
                 setLoadingModal(false);
             });
-        // Set timeout to remove alert after 5 seconds on load.
         alertTimeout.current = setTimeout(() => {
             setShowAlert(false);
         }, 5000);
@@ -94,6 +141,54 @@ const Enum4Linux = () => {
         alertTimeout.current = setTimeout(() => {
             setShowAlert(false);
         }, 5000);
+    };
+
+    // Function to validate and format parameters
+    const validateAndFormatParameter = (param: string): { isValid: boolean; formatted: string; error: string } => {
+        if (!param.trim()) {
+            return { isValid: true, formatted: "", error: "" };
+        }
+
+        // Remove any existing dashes and spaces
+        const cleanParam = param.replace(/^-+/, '').trim();
+        
+        // Check for multiple parameters (like "u username p password")
+        const parts = cleanParam.split(/\s+/);
+        let formattedParams = [];
+        let invalidParams = [];
+
+        for (let i = 0; i < parts.length; i++) {
+            const part = parts[i];
+            
+            // If it's a single letter parameter
+            if (part.length === 1 && validParams.includes(part)) {
+                formattedParams.push(`-${part}`);
+                // Check if next part is a value for this parameter
+                if (i + 1 < parts.length && !validParams.includes(parts[i + 1])) {
+                    formattedParams.push(parts[i + 1]);
+                    i++; // Skip the next part as it's a value
+                }
+            } else if (part.length === 1 && !validParams.includes(part)) {
+                invalidParams.push(part);
+            } else if (part.length > 1) {
+                // Multi-character parameters like "username", "password", etc.
+                formattedParams.push(part);
+            }
+        }
+
+        if (invalidParams.length > 0) {
+            return {
+                isValid: false,
+                formatted: "",
+                error: `Invalid parameter(s): ${invalidParams.join(', ')}. Valid options: ${validParams.join(', ')}`
+            };
+        }
+
+        return {
+            isValid: true,
+            formatted: formattedParams.join(' '),
+            error: ""
+        };
     };
 
     const handleProcessData = useCallback((data: string) => {
@@ -118,19 +213,44 @@ const Enum4Linux = () => {
     );
 
     const onSubmit = async (values: FormValuesType) => {
+        // Clear previous parameter errors
+        setParamError("");
+
+        // Validate main parameters
+        const mainParamResult = validateAndFormatParameter(values.paramMain);
+        if (!mainParamResult.isValid) {
+            setParamError(`Main Parameters: ${mainParamResult.error}`);
+            return;
+        }
+
+        // Validate additional parameters if in custom mode
+        let altParamResult = { isValid: true, formatted: "", error: "" };
+        if (customMode) {
+            altParamResult = validateAndFormatParameter(values.paramAlt);
+            if (!altParamResult.isValid) {
+                setParamError(`Additional Parameters: ${altParamResult.error}`);
+                return;
+            }
+        }
+
         setLoading(true);
         setAllowSave(false);
+        
+        // Build options string
         let options = `-${selectedOption}`;
-
         if (osinfo) options = options.concat(" -o");
 
-        let args = []; //Making args mutable, need to check if parameters are provided.
-
+        let args = [];
         args.push(options);
 
-        if (values.paramMain) args.push(values.paramMain);
+        // Add formatted parameters
+        if (mainParamResult.formatted) {
+            args.push(mainParamResult.formatted);
+        }
 
-        if (values.paramAlt) args.push(values.paramAlt);
+        if (customMode && altParamResult.formatted) {
+            args.push(altParamResult.formatted);
+        }
 
         args.push(values.ipAddress);
 
@@ -190,6 +310,13 @@ const Enum4Linux = () => {
                             own or have explicit permission to test.
                         </Alert>
                     )}
+                    
+                    {paramError && (
+                        <Alert title="Parameter Error" color="yellow">
+                            {paramError}
+                        </Alert>
+                    )}
+
                     <Switch
                         size="md"
                         label="Custom Configuration"
@@ -234,31 +361,35 @@ const Enum4Linux = () => {
                     </Tooltip>
 
                     <Tooltip
-                        label="Parameter for the chosen option like username or password if required."
+                        label="Enter parameters like 'u username p password' or 'd v' for detailed verbose output. Don't include dashes - they'll be added automatically."
                         position="right"
                         withArrow
                     >
                         <TextInput
                             label="Parameters"
                             {...form.getInputProps("paramMain")}
-                            placeholder="Example: -u <username> "
+                            placeholder="Example: u admin p password123 d v"
+                            description="Valid options: U (userlist), S (sharelist), G (groups), P (password policy), d (detailed), v (verbose), r (RID cycling), etc."
                         />
                     </Tooltip>
+                    
                     {customMode && (
                         <>
                             <Tooltip
-                                label="Additional parameter for the chosen option like password if required."
+                                label="Additional parameters for advanced options like 'R 500-600' for RID range or 's shares.txt' for share bruteforce."
                                 position="right"
                                 withArrow
                             >
                                 <TextInput
                                     label="Additional Parameters"
                                     {...form.getInputProps("paramAlt")}
-                                    placeholder="Example: -p <password> "
+                                    placeholder="Example: R 500-1000 K 10 A"
+                                    description="Advanced options: R (RID range), K (RID search limit), A (aggressive), s (share bruteforce), w (workgroup)"
                                 />
                             </Tooltip>
                         </>
                     )}
+                    
                     {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
                     <Button type="submit">Start {title}</Button>
                     <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />


### PR DESCRIPTION
### **Problem**
Enum4Linux GUI incorrectly concatenated multiple options without proper `-` prefixes:
- **Before:** `enum4linux -U S -u admin 192.168.64.5` (S treated as unknown option)
- **After:** `enum4linux -U -S -u admin 192.168.64.5` (correct tokenization)

### **Solution**
Added `validateAndFormatParameter()` function that:
- Tokenizes multiple options with individual `-` prefixes
- Validates parameters against valid enum4linux flags
- Handles parameter-value pairs correctly (`u username p password` → `-u username -p password`)
- Shows clear error messages for invalid parameters

### **Key Changes**
1. **Parameter Tokenization**: Each flag gets proper `-` prefix
2. **Input Validation**: Real-time validation with error alerts
3. **Enhanced UX**: Better tooltips, examples, and step-by-step guidance
4. **IP Validation**: Added regex validation for target IP/hostname

### **Testing Examples**
| Input | Output | Status |
|-------|--------|---------|
| `U S` | `-U -S` | Fixed |
| `u admin p pass` | `-u admin -p pass` | Working |
| `d v r` | `-d -v -r` | Working |
| `x invalid` | Error message | Validation |

**Closes #1486**