### PR TITLE
docs: add tutorial link for ExifTool

### DIFF
--- a/src/components/Exif/Exif.tsx
+++ b/src/components/Exif/Exif.tsx
@@ -48,7 +48,7 @@ const ExifTool = () => {
         "Step 4: Input a value to write to the specified metadata field.\n" +
         "Step 5: Run the tool!";
     const sourceLink = ""; // Link to the source code
-    const tutorial = "https://docs.google.com/document/d/1g4RFhVeMK3CRXRlGfSR5LMNiS4Xb5HuHcoq1K2i2J3c/edit?usp=sharing"; // Link to the official documentation/tutorial
+    const tutorial = "https://docs.google.com/document/d/16OaJNwkv2vVGVDZBNL1rORVkVOj6mqflVmByk0s1zbM/edit?usp=sharing"; // Link to the official documentation/tutorial
     const dependencies = ["exiftool"]; // ExifTool dependency.
 
     // Form hook to handle form input


### PR DESCRIPTION
Created a publicly accessible Google Docs tutorial link to the ExifTool page.