### PR TITLE
tool tutorial - docs: add tutorial guides for ExifTool and Fcrackzip

### DIFF
--- a/src/components/Exif/Exif.tsx
+++ b/src/components/Exif/Exif.tsx
@@ -48,7 +48,7 @@ const ExifTool = () => {
         "Step 4: Input a value to write to the specified metadata field.\n" +
         "Step 5: Run the tool!";
     const sourceLink = ""; // Link to the source code
-    const tutorial = "https://docs.google.com/document/d/1g4RFhVeMK3CRXRlGfSR5LMNiS4Xb5HuHcoq1K2i2J3c/edit?usp=sharing"; // Link to the official documentation/tutorial
+    const tutorial = "https://docs.google.com/document/d/16OaJNwkv2vVGVDZBNL1rORVkVOj6mqflVmByk0s1zbM/edit?tab=t.0"; // Link to the official documentation/tutorial
     const dependencies = ["exiftool"]; // ExifTool dependency.
 
     // Form hook to handle form input

--- a/src/components/Fcrackzip/Fcrackzip.tsx
+++ b/src/components/Fcrackzip/Fcrackzip.tsx
@@ -55,7 +55,7 @@ const Fcrackzip = () => {
         "Step 3: You can save output by checking 'Save Output to File'\n" +
         "Step 4: Click start cracking!";
     // Link to the tutorial
-    const tutorial = "https://docs.google.com/document/d/1VGIv2XtJWxURo35ey8PdNza4otn-SxG7ZJaHmQ7xmIs/edit?usp=sharing";
+    const tutorial = "https://docs.google.com/document/d/1m8kmNbdI3uq5Qzxaw7K3bg9b1lfOXpWC_z4_jR_rG7M/edit?tab=t.0";
     // Link to the source code
     const sourceLink = "https://www.kali.org/tools/fcrackzip/";
 


### PR DESCRIPTION
Adds Google Docs–based tutorial guides for ExifTool and Fcrackzip and integrates them into the tool UI. 