### PR TITLE
Fix #1517 - Increment Order not showing on initial load

### DIFF
--- a/src/components/JohnTheRipper/JohnTheRipper.tsx
+++ b/src/components/JohnTheRipper/JohnTheRipper.tsx
@@ -48,7 +48,7 @@ const JohnTheRipper = () => {
     const [allowSave, setAllowSave] = useState(false); //   State variable to allow saving the output to a file.
     const [hasSaved, setHasSaved] = useState(false); // State variable to indicate if the output has been saved.
     const [selectedFileTypeOption, setSelectedFileTypeOption] = useState(""); // State variable to store the selected file type.
-    const [selectedModeOption, setSelectedModeOption] = useState(""); // State variable to store the selected crack mode.
+    const [selectedModeOption, setSelectedModeOption] = useState("incremental"); // State variable to store the selected crack mode.
     const [selectedIncrementOption, setSelectedIncrementOption] = useState(""); // State variable to store the selected increment order.
     const [fileNames, setFileNames] = useState<string[]>([]); // State variable to store the file names.
 


### PR DESCRIPTION
Fixes #1517

Fixed issue where the Increment Order field was not visible on initial load when Crack Mode was set to Incremental. The issue was caused by a mismatch between the UI default value and the component state. Initialising the state to "incremental" ensures the field renders correctly on first load. 
<img width="1909" height="937" alt="image" src="https://github.com/user-attachments/assets/e5431649-2e4c-4703-8dff-7a73fac089c9" />
