### PR TITLE
Fix #1617: Add Nuclei Tool Tutorial

### DIFF
--- a/src/components/Nuclei/Nuclei.tsx
+++ b/src/components/Nuclei/Nuclei.tsx
@@ -24,7 +24,7 @@ function Nuclei() {
 
     const title = "Nuclei";
     const description = "Nuclei is a fast and customizable vulnerability scanner based on simple YAML-based templates.";
-    const tutorial = "https://nuclei.projectdiscovery.io/";
+    const tutorial = "https://docs.google.com/document/d/1Blzt6KZLcI1J0CtPu6cZwU_P3HgEaRe1RQ1E-okEGTY/edit?usp=sharing";
     const sourceLink = "https://github.com/projectdiscovery/nuclei";
     const dependencies = ["nuclei"];
 

--- a/src/components/tiger/tiger.tsx
+++ b/src/components/tiger/tiger.tsx
@@ -39,7 +39,7 @@ const Tiger = () => {
         "Step 3: Check the results displayed in the output block or the saved report file at the specified location. ";
     const sourceLink = "https://www.kali.org/tools/tiger/";
     const dependencies = ["tiger"];
-    const tutorial = "https://docs.google.com/document/d/1bkG-s9h6bpsCWq2IW1pOJbxpCPc_ZcqNwswup_iSB5k/edit?usp=sharing";
+    const tutorial = "https://docs.google.com/document/d/1dE_S5HIlWfSedTMu0_m0YngNYASxmw0RUL0pnCblH8A/edit?usp=sharing";
 
     let form = useForm({
         initialValues: {


### PR DESCRIPTION
Related to "[Feature Request]: Nuclei Tutorial #1617"

Tool tutorial guide can be found at this [Google Doc](https://docs.google.com/document/d/1Blzt6KZLcI1J0CtPu6cZwU_P3HgEaRe1RQ1E-okEGTY/edit?usp=drive_link).
