### PR TITLE
#Bug #1619: Fix Nuclei clear output button 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
 
             # Vulnerability scanning
             - name: Run Trivy vulnerability scanner in repo mode
-              uses: aquasecurity/trivy-action@master
+              uses: aquasecurity/trivy-action@0.28.0
               with:
                   scan-type: "fs"
                   ignore-unfixed: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
 
             # Vulnerability scanning
             - name: Run Trivy vulnerability scanner in repo mode
-              uses: aquasecurity/trivy-action@0.28.0
+              uses: aquasecurity/trivy-action@master
               with:
                   scan-type: "fs"
                   ignore-unfixed: true

--- a/src/components/Nuclei/Nuclei.tsx
+++ b/src/components/Nuclei/Nuclei.tsx
@@ -55,6 +55,10 @@ function Nuclei() {
         setLoading(false);
     }, []);
 
+    const clearOutput = useCallback(() => {
+        setOutput("");
+    }, []);
+
     const onSubmit = async () => {
         setLoading(true);
         const args = ["-u", form.values.target];
@@ -104,7 +108,7 @@ function Nuclei() {
                     </Button>
                 </Stack>
             </form>
-            <ConsoleWrapper output={output} />
+            <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
         </RenderComponent>
     );
 }

--- a/src/components/WPScan/WPScan.tsx
+++ b/src/components/WPScan/WPScan.tsx
@@ -68,7 +68,7 @@ function WPScan() {
         "API Token: For the API Token field, head to the WPScan website and make a free account.\n" +
         "           Once logged in, you can visit the API Token section and copy it into the tool.\n";
     const sourceLink = "https://github.com/wpscanteam/wpscan";
-    const tutorial = "https://docs.google.com/document/d/1qkCw-Ktjih6C1R_ylEbVJlDwfJLpxmL7W7leO17AjS0/edit?usp=sharing";
+    const tutorial = "https://docs.google.com/document/d/1qaVRFdtfx4BDQ8-tT0zIIo5YfLdk27XOIL7mOnO1HW0/edit?usp=sharing";
     const dependencies = ["wpscan"];
 
     // Initialize the form hook with initial values


### PR DESCRIPTION
This bug fix addresses Issue #1619, where pressing the Clear Output button in the Nuclei component did not clear the displayed scan output.

The issue occurred because Nuclei.tsx rendered the ConsoleWrapper component with only the output prop. Although ConsoleWrapper already supported a clearOutputCallback prop and connected it to the Clear Output button, no callback was being passed from the Nuclei component. As a result, the button click had no function to execute, making the button appear non-functional.

This change adds a clearOutput callback inside Nuclei.tsx that resets the output state using setOutput(""). The callback is then passed into ConsoleWrapper through the clearOutputCallback prop, allowing the existing Clear Output button to properly clear the console display.

Changes included:
- Added a clearOutput callback in Nuclei.tsx
- Reset the Nuclei output state when Clear Output is clicked
- Passed clearOutput into ConsoleWrapper using the clearOutputCallback prop
- Fixed the Clear Output button behavior without changing ConsoleWrapper itself

Fixes #1619