### PR TITLE
[Bug Fix #1606] John the Ripper now displays uploaded file

### DIFF
--- a/src/components/FileHandler/FilePicker.tsx
+++ b/src/components/FileHandler/FilePicker.tsx
@@ -90,21 +90,18 @@ export function FilePicker({
                     input: { display: "none" }, // Hide the native input
                 }}
             />
-            <label
-                style={{ cursor: "pointer", display: "inline-block" }}
-                onClick={() => {
-                    const fileInput = document.querySelector("input[type='file']") as HTMLInputElement;
-                    fileInput?.click(); // Using type assertion to ensure it's an HTMLInputElement
-                }}
-            >
-                <img
-                    src="https://static-00.iconduck.com/assets.00/cloud-upload-icon-2048x2048-fej4g14p.png"
-                    alt="Upload"
-                    width={80}
-                    height={80}
-                />
-                <div style={{ fontSize: "14px", color: "#666" }}>{placeholderText}</div>
-            </label>
+            {fileNames.length === 0 && ( //Only show upload icon when no file is selected
+                <label
+                    style={{ cursor: "pointer", display: "inline-block" }}
+                    onClick={() => {
+                        const fileInput = document.querySelector("input[type='file']") as HTMLInputElement;
+                        fileInput?.click(); // Using type assertion to ensure it's an HTMLInputElement
+                    }}
+                >
+                    <img src="https://www.svgrepo.com/show/499790/upload.svg" alt="Upload" width={80} height={80} />
+                    <div style={{ fontSize: "14px", color: "#666" }}>{placeholderText}</div>
+                </label>
+            )}
         </div>
     );
 }

--- a/src/components/JohnTheRipper/JohnTheRipper.tsx
+++ b/src/components/JohnTheRipper/JohnTheRipper.tsx
@@ -307,6 +307,11 @@ const JohnTheRipper = () => {
                         labelText="File (Can only select files in /home/kali)"
                         placeholderText="Click to select file(s)"
                     />
+                    {fileNames.length > 0 && (
+                        <div style={{ fontSize: "16px", color: "#aaa", marginTop: "8px", textAlign: "center" }}>
+                            <strong>Uploaded File:</strong> {cleanFileName(fileNames[0])}
+                        </div>
+                    )}
                     <TextInput label={"Hash Type (if known)"} {...form.getInputProps("hash")} />
                     <NativeSelect
                         value={selectedModeOption}

--- a/src/components/SnmpCheck/SnmpCheck.tsx
+++ b/src/components/SnmpCheck/SnmpCheck.tsx
@@ -28,7 +28,8 @@ const steps =
     "Step 2: (Optional) Specify a target port number (default port: 161).\n" +
     "Step 3: Click the 'Scan' button to initiate the SnmpCheck.\n";
 const sourceLink = "https://www.kali.org/tools/snmpcheck/"; // Link to the source code.
-const tutorial = "https://docs.google.com/document/d/1wi_rpyOfYU81o5x4kCmNrL9NzfZsKZPP/edit?usp=sharing&ouid=116708520276732350458&rtpof=true&sd=true"; // Link to the official documentation/tutorial.
+const tutorial =
+    "https://docs.google.com/document/d/1wi_rpyOfYU81o5x4kCmNrL9NzfZsKZPP/edit?usp=sharing&ouid=116708520276732350458&rtpof=true&sd=true"; // Link to the official documentation/tutorial.
 const dependencies = ["snmp-check"]; // Contains the dependencies required by the component.
 
 /**

--- a/src/components/SnmpCheck/SnmpCheck.tsx
+++ b/src/components/SnmpCheck/SnmpCheck.tsx
@@ -28,7 +28,7 @@ const steps =
     "Step 2: (Optional) Specify a target port number (default port: 161).\n" +
     "Step 3: Click the 'Scan' button to initiate the SnmpCheck.\n";
 const sourceLink = "https://www.kali.org/tools/snmpcheck/"; // Link to the source code.
-const tutorial = "https://docs.google.com/document/d/1sp08LtXvs08jKf9gN4pXZdjTJaF8oGaXe3vHkaepsVU/edit?usp=sharing"; // Link to the official documentation/tutorial.
+const tutorial = "https://docs.google.com/document/d/1wi_rpyOfYU81o5x4kCmNrL9NzfZsKZPP/edit?usp=sharing&ouid=116708520276732350458&rtpof=true&sd=true"; // Link to the official documentation/tutorial.
 const dependencies = ["snmp-check"]; // Contains the dependencies required by the component.
 
 /**

--- a/src/components/SnmpCheck/SnmpCheck.tsx
+++ b/src/components/SnmpCheck/SnmpCheck.tsx
@@ -28,8 +28,7 @@ const steps =
     "Step 2: (Optional) Specify a target port number (default port: 161).\n" +
     "Step 3: Click the 'Scan' button to initiate the SnmpCheck.\n";
 const sourceLink = "https://www.kali.org/tools/snmpcheck/"; // Link to the source code.
-const tutorial =
-    "https://docs.google.com/document/d/1wi_rpyOfYU81o5x4kCmNrL9NzfZsKZPP/edit?usp=sharing&ouid=116708520276732350458&rtpof=true&sd=true"; // Link to the official documentation/tutorial.
+const tutorial = "https://docs.google.com/document/d/1sp08LtXvs08jKf9gN4pXZdjTJaF8oGaXe3vHkaepsVU/edit?usp=sharing"; // Link to the official documentation/tutorial.
 const dependencies = ["snmp-check"]; // Contains the dependencies required by the component.
 
 /**


### PR DESCRIPTION
Bug Fix for: https://github.com/Hardhat-Enterprises/Deakin-Detonator-Toolkit/issues/1606

**Changes made:**

FilePicker.tsx:
- Replaced the broken upload icon with a working one.
- The upload icon now hides once a file is selected and reappears when the file is deselected by pressing x.

JohnTheRipper.tsx:
- Added a filename display that appears once a file is selected. Uses the existing cleanFileName function to remove the timestamp/UUID so the filename is readable.

**Before:** The upload icon was not displaying correctly and there was no indication of which file had been selected.
<img width="900" height="105" alt="before" src="https://github.com/user-attachments/assets/d9ddc0ba-d30f-43d3-9acb-934a8659de2e" />

**After:** Selecting a file hides the upload icon and shows the filename below. Clicking the x button clears the selection and restores the upload icon.

<img width="1488" height="376" alt="after" src="https://github.com/user-attachments/assets/b31a0f3b-4985-488a-9f6b-8f16daf670e6" />

<img width="1489" height="284" alt="after 2" src="https://github.com/user-attachments/assets/dc1c6403-0f84-4819-88a9-1178578919c2" />