### PR TITLE
Request #1618: Output textbox extension

### DIFF
--- a/src/components/ConsoleWrapper/ConsoleWrapper.tsx
+++ b/src/components/ConsoleWrapper/ConsoleWrapper.tsx
@@ -25,7 +25,7 @@ const ConsoleWrapper = ({ output, clearOutputCallback, hideClearButton, title = 
         return (
             <>
                 <Title>{title}</Title>
-                <div ref={outputContainerRef} style={{ maxHeight: "250px", overflowY: "auto" }}>
+                <div ref={outputContainerRef} style={{ maxHeight: "500px", overflowY: "auto" }}>
                     <Prism language={"bash"}>{output}</Prism>
                 </div>
                 {!hideClearButton && (

--- a/src/components/Nuclei/Nuclei.tsx
+++ b/src/components/Nuclei/Nuclei.tsx
@@ -24,7 +24,7 @@ function Nuclei() {
 
     const title = "Nuclei";
     const description = "Nuclei is a fast and customizable vulnerability scanner based on simple YAML-based templates.";
-    const tutorial = "https://nuclei.projectdiscovery.io/";
+    const tutorial = "https://docs.google.com/document/d/1Blzt6KZLcI1J0CtPu6cZwU_P3HgEaRe1RQ1E-okEGTY/edit?usp=sharing";
     const sourceLink = "https://github.com/projectdiscovery/nuclei";
     const dependencies = ["nuclei"];
 


### PR DESCRIPTION
This change originally only addressed [Improvement Request]: Extended Nuclei Output Textbox #1618. However upon inspection, this change would improve overall user experience for viewing outputs for the various tools. 

Either way, the output textbox size was not individually determined for each tool. The output textbox is decided by 'ConsoleWrapper.tsx' where every tool calls to. 

'maxHeight' was changed to 500px from 250px. 