### PR TITLE
[Bug Fix #1608] John the Ripper now handles receiving no input file

### DIFF
--- a/src/components/JohnTheRipper/JohnTheRipper.tsx
+++ b/src/components/JohnTheRipper/JohnTheRipper.tsx
@@ -176,6 +176,12 @@ const JohnTheRipper = () => {
      * @param {FormValuesType} values - The form values, containing the filepath, hash, crack mode, and other options.
      */
     const onSubmit = async (values: FormValuesType) => {
+        // Validate that a file has been selected before proceeding.
+        if (!fileNames || fileNames.length === 0) {
+            setOutput("Error: No input file selected. Please select a file before attempting to crack.");
+            return;
+        }
+
         // Activate loading state to indicate ongoing process.
         setLoading(true);
 
@@ -307,6 +313,11 @@ const JohnTheRipper = () => {
                         labelText="File (Can only select files in /home/kali)"
                         placeholderText="Click to select file(s)"
                     />
+                    {fileNames.length > 0 && (
+                        <div style={{ fontSize: "16px", color: "#aaa", marginTop: "8px", textAlign: "center" }}>
+                            <strong>Uploaded File:</strong> {cleanFileName(fileNames[0])}
+                        </div>
+                    )}
                     <TextInput label={"Hash Type (if known)"} {...form.getInputProps("hash")} />
                     <NativeSelect
                         value={selectedModeOption}


### PR DESCRIPTION
**Changes Made:** 
- Added an input validation check at the start of onSubmit. 
- If no file is selected, an error message is displayed in the console and the tool does not run. 

**Before Changes:** 
If no input file was provided, John the Ripper would still attempt to run, causing the tool to lock up and become unresponsive. before 
<img width="940" height="443" alt="before" src="https://github.com/user-attachments/assets/65a4ad1d-5285-40f9-9b8a-afb155502a01" />

**After Changes:** 
If no file is selected when Crack is clicked, an error message is shown and the tool does not attempt to run, keeping it responsive.
<img width="1490" height="768" alt="Screenshot 2026-05-09 124423" src="https://github.com/user-attachments/assets/91a3ef9a-1eb9-48a3-b629-31533a1d26da" />
