### PR TITLE
Fix John the Ripper dictionary path binding for bug #1605

### DIFF
--- a/src/components/JohnTheRipper/JohnTheRipper.tsx
+++ b/src/components/JohnTheRipper/JohnTheRipper.tsx
@@ -328,7 +328,7 @@ const JohnTheRipper = () => {
                     />
                     {modeRequiringWordList.includes(selectedModeOption) && (
                         <>
-                            <TextInput label={"Dictionary File Path"} required {...form.getInputProps("wordlist")} />
+                            <TextInput label={"Dictionary File Path"} required {...form.getInputProps("wordList")} />
                         </>
                     )}
                     {modeRequiringIncrementOrder.includes(selectedModeOption) && (


### PR DESCRIPTION
## Summary
This PR fixes bug #1605 in the John the Ripper component.

## Issue
When dictionary mode was selected and a custom dictionary file path was entered, the generated John the Ripper command showed `--wordlist=` with no value being passed. As a result, John the Ripper fell back to the default wordlist instead of using the user-provided dictionary file.

## Cause
The issue was caused by a mismatch between the Dictionary File Path input binding and the form value used to build the command:
- the input field used `form.getInputProps("wordlist")`
- the command generation used `values.wordList`

Because of this mismatch, the entered dictionary path was not passed correctly.

## Fix
Updated the Dictionary File Path input binding to use `wordList` consistently so the selected dictionary file path is now passed correctly into the command.

## Retesting
Retested in DDT using:
- `/home/kali/testhash.txt`
- dictionary mode
- file type `raw`
- custom dictionary path `/home/kali/mywordlist.txt`

After the fix, the generated command correctly included:
`--wordlist=/home/kali/mywordlist.txt`

## Evidence
Bug was reproduced before fix and confirmed resolved after retesting.