### PR TITLE
Investigate and improve WhatWeb behavior for bug #1446

### DIFF
--- a/src/components/JohnTheRipper/JohnTheRipper.tsx
+++ b/src/components/JohnTheRipper/JohnTheRipper.tsx
@@ -328,7 +328,7 @@ const JohnTheRipper = () => {
                     />
                     {modeRequiringWordList.includes(selectedModeOption) && (
                         <>
-                            <TextInput label={"Dictionary File Path"} required {...form.getInputProps("wordlist")} />
+                            <TextInput label={"Dictionary File Path"} required {...form.getInputProps("wordList")} />
                         </>
                     )}
                     {modeRequiringIncrementOrder.includes(selectedModeOption) && (

--- a/src/components/WhatWeb/WhatWeb.tsx
+++ b/src/components/WhatWeb/WhatWeb.tsx
@@ -130,12 +130,12 @@ function WhatWeb() {
 
         const args: string[] = [];
         if (values.inputFile) args.push(`-i ${values.inputFile}`);
-        if (values.aggression) args.push(`-a ${values.aggression}`);
+        if (values.aggression) args.push("-a", values.aggression);
         if (values.userAgent) args.push(`-U "${values.userAgent}"`);
         if (values.followRedirect) args.push(`--follow-redirect=${values.followRedirect}`);
         if (values.user) args.push(`-u ${values.user}`);
         if (values.cookie) args.push(`-c "${values.cookie}"`);
-        if (values.plugins) args.push(`-p ${values.plugins}`);
+        if (values.plugins) args.push("-p", values.plugins);
         if (values.verbose) args.push("-v");
         if (values.logFormat) args.push(`--log-${values.logFormat}=-`);
         if (values.maxThreads > 0) args.push(`-t ${values.maxThreads}`);
@@ -345,7 +345,7 @@ function WhatWeb() {
                         </Group>
 
                         <div style={{ height: fullscreen ? "80vh" : "300px" }}>
-                            <ConsoleWrapper output={formatOutput(output)} clearOutputCallback={clearOutput} />
+			<ConsoleWrapper output={formatOutput(output)} clearOutputCallback={clearOutput} />                            
                         </div>
                     </Stack>
                 </form>

--- a/src/components/WhatWeb/WhatWeb.tsx
+++ b/src/components/WhatWeb/WhatWeb.tsx
@@ -48,6 +48,7 @@ function WhatWeb() {
     const [advancedOpened, setAdvancedOpened] = useState(false);
     const [authOpened, setAuthOpened] = useState(false);
     const [fullscreen, setFullscreen] = useState(false);
+    const [timeoutId, setTimeoutId] = useState<ReturnType<typeof setTimeout> | null>(null);
 
     // Declare constants
     const title = "WhatWeb";
@@ -103,20 +104,35 @@ function WhatWeb() {
     }, []);
 
     const handleProcessTermination = useCallback(
-        ({ code, signal }: { code: number; signal: number }) => {
-            if (code === 0) {
-                handleProcessData("\nProcess completed successfully.");
+      ({ code, signal }: { code: number; signal: number }) => {
+	if (timeoutId) {
+	    clearTimeout(timeoutId);
+            setTimeoutId(null);
+	}
+        setOutput((prevOutput) => {
+            const hasError =
+                prevOutput.includes("ERROR") ||
+                prevOutput.includes("execution expired") ||
+                prevOutput.includes("No plugins selected") ||
+                prevOutput.includes("not found");
+
+            if (code === 0 && !hasError) {
+                return prevOutput + "\nProcess completed successfully.";
             } else if (signal === 15) {
-                handleProcessData("\nProcess was manually terminated.");
+                return prevOutput + "\nProcess was manually terminated.";
+            } else if (code === 0 && hasError) {
+                return prevOutput + "\nProcess finished with errors.";
             } else {
-                handleProcessData(`\nProcess terminated with exit code: ${code} and signal code: ${signal}`);
+                return prevOutput + `\nProcess terminated with exit code: ${code} and signal code: ${signal}`;
             }
-            setLoading(false);
-            setAllowSave(true);
-            setHasSaved(false);
-        },
-        [handleProcessData]
-    );
+        });
+
+        setLoading(false);
+        setAllowSave(true);
+        setHasSaved(false);
+    },
+    []
+);
 
     const handleSaveComplete = () => {
         setHasSaved(true);
@@ -125,20 +141,21 @@ function WhatWeb() {
 
     // Submit handler
     const onSubmit = async (values: FormValuesType) => {
+	setOutput("");
         setLoading(true);
         setAllowSave(false);
 
         const args: string[] = [];
-        if (values.inputFile) args.push(`-i ${values.inputFile}`);
-        if (values.aggression) args.push("-a", values.aggression);
-        if (values.userAgent) args.push(`-U "${values.userAgent}"`);
-        if (values.followRedirect) args.push(`--follow-redirect=${values.followRedirect}`);
-        if (values.user) args.push(`-u ${values.user}`);
-        if (values.cookie) args.push(`-c "${values.cookie}"`);
-        if (values.plugins) args.push("-p", values.plugins);
-        if (values.verbose) args.push("-v");
-        if (values.logFormat) args.push(`--log-${values.logFormat}=-`);
-        if (values.maxThreads > 0) args.push(`-t ${values.maxThreads}`);
+        if (values.inputFile) args.push("-i", values.inputFile);
+	if (values.aggression) args.push("-a", values.aggression);
+	if (values.userAgent) args.push("-U", values.userAgent);
+	if (values.followRedirect) args.push(`--follow-redirect=${values.followRedirect}`);
+	if (values.user) args.push("-u", values.user);
+	if (values.cookie) args.push("-c", values.cookie);
+	if (values.plugins) args.push("-p", values.plugins);
+	if (values.verbose) args.push("-v");
+	if (values.logFormat) args.push(`--log-${values.logFormat}=-`);
+	if (values.maxThreads > 0) args.push("-t", String(values.maxThreads));
         args.push(values.target);
 
         try {
@@ -150,6 +167,17 @@ function WhatWeb() {
             );
             setPid(pid);
             setOutput(output);
+
+	    const timer = setTimeout(() => {
+                if (pid) {
+                    CommandHelper.runCommand("kill", ["-15", pid]);
+                    setOutput((prevOutput) => prevOutput + "\nScan timed out after 120 seconds.");
+                    setLoading(false);
+                    setAllowSave(true);
+                    setHasSaved(false);
+                }
+            }, 120000);
+	    setTimeoutId(timer);
         } catch (error: any) {
             setOutput(`Error: ${error.message}`);
             setLoading(false);
@@ -345,7 +373,7 @@ function WhatWeb() {
                         </Group>
 
                         <div style={{ height: fullscreen ? "80vh" : "300px" }}>
-			<ConsoleWrapper output={formatOutput(output)} clearOutputCallback={clearOutput} />                            
+			<ConsoleWrapper output={output} clearOutputCallback={clearOutput} />                            
                         </div>
                     </Stack>
                 </form>


### PR DESCRIPTION
## Summary
This PR investigates and improves WhatWeb behaviour for bug #1446 in the Deakin Detonator Toolkit (DDT).

## Ticket scope
The original issue reported three main problems:
- IP input fails
- aggression hangs
- plugins not detected
- failed runs still end with misleading success output

## Findings
During testing in DDT:
- IP input with `1.1.1.1` worked successfully
- IP input with `8.8.8.8` showed an HTTP timeout before continuing successfully over HTTPS
- aggression levels such as `Stealthy` and `Aggressive` completed successfully
- `Heavy` aggression did not complete normally and originally appeared to hang
- plugin handling was inconsistent and required investigation
- failed/problematic runs could still end with `Process completed successfully`, which was misleading

Additional terminal testing showed:
- `whatweb -a 4 1.1.1.1` also timed out outside DDT, suggesting the Heavy aggression issue is not limited only to the DDT interface

## Changes made
The following WhatWeb improvements were applied in `WhatWeb.tsx`:
- updated command argument handling so option flags and values are passed as separate arguments
- improved plugin argument passing
- improved aggression argument passing
- updated process termination handling so error cases no longer end with the misleading message `Process completed successfully`
- added timeout handling so long-running WhatWeb scans stop after 120 seconds with a clear timeout message instead of hanging indefinitely in DDT

## Result
After the changes:
- plugin-based runs were successfully retested using valid targets, including `wordpress` on `https://wordpress.com`
- error cases now end with a clearer message such as `Process finished with errors`
- Heavy aggression no longer hangs indefinitely in DDT and now stops with a timeout message after 120 seconds
- IP behaviour was further investigated and documented based on multiple test targets

## Notes
The Heavy aggression issue appears reproducible at the WhatWeb/tool level as well, based on terminal testing, but DDT now handles the behaviour more safely by timing out instead of hanging forever.