### PR TITLE
Fix #1509: Enable Save Output to File for ExifTool

### DIFF
--- a/src/components/Exif/Exif.tsx
+++ b/src/components/Exif/Exif.tsx
@@ -133,6 +133,7 @@ const ExifTool = () => {
 
             // Cancel the loading overlay. The process has completed.
             setLoading(false);
+            setAllowSave(true);
         },
         [handleProcessData] // Dependency on the handleProcessData callback
     );


### PR DESCRIPTION
**Changes:**
- Added 'setAllowSave(true)' inside 'handleProcessTermination' in Exif.tsx to enable the Save Output button after process completion, consistent with the implementation pattern used across other tools in the codebase.

**Before:**
- The Save Output button was never enabled after tool execution, as 'allowSave' remained false regardless of whether the process completed successfully, was manually cancelled, or terminated with an error.
<img width="1496" height="857" alt="No save button" src="https://github.com/user-attachments/assets/05f60496-7935-4aab-b302-a5276ece1dca" />

**After:**
- The Save Output button is correctly enabled upon process completion in all cases: successful completion, manual cancellation, and error exit, allowing users to save Exif results to a text file.
<img width="1492" height="840" alt="Save button added" src="https://github.com/user-attachments/assets/350ca40e-8a0a-4f50-9a0d-e2ba2313402f" />
