### PR TITLE
#Bug #1581: Added new supported sources for TheHarvester

### DIFF
--- a/src/components/theharvester/theharvester.tsx
+++ b/src/components/theharvester/theharvester.tsx
@@ -238,32 +238,43 @@ const TheHarvester = () => {
                         <label>Source</label>
                         <select {...form.getInputProps("source")}>
                             <option value="baidu">Baidu</option>
+                            <option value="bevigil">BeVigil</option>
                             <option value="bing">Bing</option>
+                            <option value="bingapi">Bing API</option>
+                            <option value="brave">Brave</option>
+                            <option value="bufferoverun">BufferOverRun</option>
                             <option value="censys">Censys</option>
                             <option value="certspotter">Certspotter</option>
-                            <option value="crtsh">Crtsh</option>
-                            <option value="dnsdumpster">DNSdumpster</option>
+                            <option value="criminalip">Criminal IP</option>
+                            <option value="crtsh">crt.sh</option>
+                            <option value="dehashed">DeHashed</option>
+                            <option value="dnsdumpster">DNSDumpster</option>
                             <option value="duckduckgo">DuckDuckGo</option>
-                            <option value="exalead">Exalead</option>
-                            <option value="google">Google</option>
-                            <option value="hackertarget">Hackertarget</option>
+                            <option value="fullhunt">FullHunt</option>
+                            <option value="github-code">GitHub Code</option>
+                            <option value="hackertarget">HackerTarget</option>
                             <option value="hunter">Hunter</option>
+                            <option value="hunterhow">HunterHow</option>
                             <option value="intelx">Intelx</option>
-                            <option value="linkedin">Linkedin</option>
-                            <option value="linkedin_links">Linkedin Links</option>
-                            <option value="netcraft">Netcraft</option>
-                            <option value="otx">Otx</option>
+                            <option value="netlas">Netlas</option>
+                            <option value="onyphe">Onyphe</option>
+                            <option value="otx">OTX</option>
+                            <option value="pentesttools">PentestTools</option>
+                            <option value="projectdiscovery">ProjectDiscovery</option>
+                            <option value="rapiddns">RapidDNS</option>
+                            <option value="rocketreach">RocketReach</option>
                             <option value="securityTrails">SecurityTrails</option>
-                            <option value="shodan">Shodan</option>
-                            <option value="spyse">Spyse</option>
-                            <option value="sublist3r">Sublist3r</option>
-                            <option value="threatcrowd">Threatcrowd</option>
-                            <option value="threatminer">Threatminer</option>
-                            <option value="trello">Trello</option>
-                            <option value="twitter">Twitter</option>
-                            <option value="vhost">Vhost</option>
-                            <option value="virustotal">Virustotal</option>
+                            <option value="sitedossier">SiteDossier</option>
+                            <option value="subdomaincenter">Subdomain Center</option>
+                            <option value="subdomainfinderc99">Subdomain Finder C99</option>
+                            <option value="threatminer">ThreatMiner</option>
+                            <option value="tomba">Tomba</option>
+                            <option value="urlscan">URLScan</option>
+                            <option value="virustotal">VirusTotal</option>
                             <option value="yahoo">Yahoo</option>
+                            <option value="whoisxml">WhoisXML</option>
+                            <option value="zoomeye">ZoomEye</option>
+                            <option value="venacus">Venacus</option>
                         </select>
                         {checkedAdvanced && (
                             <>


### PR DESCRIPTION
## Summary

Updated the TheHarvester source dropdown options to match the currently supported source modules

## Changes

Modified the `<option>` entries in `src/components/theharvester/theharvester.tsx` for the Source dropdown.

### Removed unsupported/outdated sources

- `exalead`
- `google`
- `linkedin`
- `linkedin_links`
- `netcraft`
- `spyse`
- `sublist3r`
- `threatcrowd`
- `trello`
- `twitter`
- `vhost`

### Added supported sources

- `bevigil`
- `bingapi`
- `brave`
- `bufferoverun`
- `criminalip`
- `dehashed`
- `fullhunt`
- `github-code`
- `hunterhow`
- `netlas`
- `onyphe`
- `pentesttools`
- `projectdiscovery`
- `rapiddns`
- `rocketreach`
- `sitedossier`
- `subdomaincenter`
- `subdomainfinderc99`
- `tomba`
- `urlscan`
- `whoisxml`
- `zoomeye`
- `venacus`

This ensures the UI only presents TheHarvester source modules that are currently supported, preventing users from selecting outdated sources that fail with unsupported engine errors

<img width="1528" height="420" alt="Screenshot 2026-05-16 232705" src="https://github.com/user-attachments/assets/bf2f4ad1-40d4-487a-b3fb-7ad63605e78f" />
