### PR TITLE
Fix CVE-2022-24112: Cancel button termination and URL formatting

### DIFF
--- a/src/components/CVE-2022-24112/CVE-2022-24112.tsx
+++ b/src/components/CVE-2022-24112/CVE-2022-24112.tsx
@@ -3,28 +3,18 @@ import { useForm } from "@mantine/form";
 import { useCallback, useEffect, useState } from "react";
 import { CommandHelper } from "../../utils/CommandHelper";
 import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
-import { Child, Command } from "@tauri-apps/api/shell";
-import { IconDoorExit } from "@tabler/icons";
 import { RenderComponent } from "../UserGuide/UserGuide";
-import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile"; //v2
+import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFile";
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 import InstallationModal from "../InstallationModal/InstallationModal";
 
-/**
- * FormValues defines the structure of the object used to hold form state for network configuration.
- *
- * @field hostIP: The IP address of the host machine.
- * @field targetIP: The IP address of the target machine.
- * @field hostPort: The port number on the host machine used for communication.
- */
 interface FormValuesType {
     hostIP: string;
     targetIP: string;
     hostPort: number;
 }
-// The title displayed in the user guide and form header
+
 const title = "Apache-APISIX-2022-24112";
-// Description used to inform the user about the exploit
 const description =
     "Apache APISIX CVE-2022-24112: This tool allows exploitation of an IP restriction vulnerability in Apache APISIX \n" +
     "that can lead to remote code execution. The vulnerability is due to the default API key usage in combination with \n" +
@@ -32,180 +22,101 @@ const description =
     "port can reduce the attack's impact, but do not fully mitigate it.\n";
 
 const steps =
-    "Step 1: Enter a Host IP (enter your machine’s IP for the reverse shell).\n" +
+    "Step 1: Enter a Host IP (enter your machine's IP for the reverse shell).\n" +
     "Step 2: Enter a Host Port (for reverse shell).\n" +
     "Step 3: Enter a Target IP or Hostname.\n" +
     "Step 4: Click Exploit to commence the exploits operation.\n" +
     "Step 5: View the Output block below to view the results of the attack vectors execution.\n";
 
-const sourceLink = "https://github.com/M4xSec/Apache-APISIX-CVE-2022-24112"; // Link to the source code.
+const sourceLink = "https://github.com/M4xSec/Apache-APISIX-CVE-2022-24112";
+const tutorial = "";
+const dependencies = ["python3"];
 
-const tutorial = ""; //Link to the official tutorial.
-const dependencies = [""]; // Contains the dependencies required by the component.
-/**
- * CVE20224112 is a React component that renders a form to execute
- * the Apache APISIX CVE-2022-24112 exploit.
- * It handles form submission, command execution, and output display.
- *
- * @returns A form component for executing the CVE-2022-24112 exploit.
- */
 export function CVE202224112() {
-    // State to manage the loading indicator visibility
     const [loading, setLoading] = useState(false);
-    // State to store the handle of the spawned command process
-    const [handle, setHandle] = useState<Child | null>(null);
-    // State to store the command output
     const [output, setOutput] = useState("");
-    // State to store the first status message
-    const [text1, setText1] = useState<string | null>(null);
-    // State to store the second status message
-    const [text2, setText2] = useState<string | null>(null);
-    // State to manage whether saving the output to a file is allowed
     const [allowSave, setAllowSave] = useState(false);
-    // State to track if the output has been saved
     const [hasSaved, setHasSaved] = useState(false);
-
     const [pid, setPid] = useState("");
-    // State variable to store the process ID of the command execution.
-
     const [loadingModal, setLoadingModal] = useState(true);
-    // State variable to indicate loading state of the modal.
     const [isCommandAvailable, setIsCommandAvailable] = useState(false);
-    // State variable to check if the command is available.
     const [opened, setOpened] = useState(!isCommandAvailable);
-    // State variable that indicates if the modal is opened.
 
-    // Initialize the form with default values
     let form = useForm({
         initialValues: {
             hostIP: "",
             targetIP: "",
-            hostPort: 4444, // Default port for reverse shell
+            hostPort: 4444,
         },
     });
 
-    // Check if the command is available and set the state variables accordingly.
     useEffect(() => {
-        // Check if the command is available and set the state variables accordingly.
         checkAllCommandsAvailability(dependencies)
             .then((isAvailable) => {
-                setIsCommandAvailable(isAvailable); // Set the command availability state
-                setOpened(!isAvailable); // Set the modal state to opened if the command is not available
-                setLoadingModal(false); // Set loading to false after the check is done
+                setIsCommandAvailable(isAvailable);
+                setOpened(!isAvailable);
+                setLoadingModal(false);
             })
             .catch((error) => {
                 console.error("An error occurred:", error);
-                setLoadingModal(false); // Also set loading to false in case of error
+                setLoadingModal(false);
             });
     }, []);
 
-    /**
-     * Handles incoming data from a child process and appends it to the current output state.
-     * @param {string} data - The string data recieved from the child process.
-     */
     const handleProcessData = useCallback((data: string) => {
-        setOutput((prevOutput) => prevOutput + "\n" + data); // Append new data to the previous output.
+        setOutput((prevOutput) => prevOutput + "\n" + data);
     }, []);
-    /**
-     * handleProcessTermination: Callback to handle the termination of the child process.
-     * Once the process termination is handled, it clears the process PID reference and
-     * deactivates the loading overlay.
-     * @param {object} param - An object containing information about the process termination.
-     * @param {number} param.code - The exit code of the terminated process.
-     * @param {number} param.signal - The signal code indicating how the process was terminated.
-     */
+
     const handleProcessTermination = useCallback(
         ({ code, signal }: { code: number; signal: number }) => {
-            // If the process was successful, display a success message.
             if (code === 0) {
                 handleProcessData("\nProcess completed successfully.");
-                // If the process was terminated manually, display a termination message.
             } else if (signal === 15) {
                 handleProcessData("\nProcess was manually terminated.");
-                // If the process was terminated with an error, display the exit and signal codes.
             } else {
                 handleProcessData(`\nProcess terminated with exit code: ${code} and signal code: ${signal}`);
             }
-            // Clear the child process pid reference. There is no longer a valid process running.
+            // Clear PID and stop loading once process ends
             setPid("");
-            // Cancel the Loading Overlay. The process has completed.
             setLoading(false);
         },
         [handleProcessData]
     );
 
-    /**
-     * Handles form submission, executes the exploit command, and updates the output state.
-     *
-     * @param values - The form values containing host IP, target IP, and host port.
-     */
     const onSubmit = async (values: FormValuesType) => {
         setLoading(true);
-
-        // Disallow saving until the tool's execution is complete
         setAllowSave(false);
 
-        // Define the command arguments to be executed
-        const args = ["./exploits/CVE-2022-24112.py", values.targetIP, values.hostIP, `${values.hostPort}`];
+        const args = [
+            "./exploits/CVE-2022-24112.py",
+            `http://${values.targetIP}:9080/`,
+            values.hostIP,
+            `${values.hostPort}`,
+        ];
 
-        // Create a new command instance and spawn it
-        const command = new Command("python3", args);
-        const newHandle = await command.spawn();
-
-        // Run the command and capture the output
-        const output = await CommandHelper.runCommand("python3", args);
-
-        // Update status texts with current operation information
-        const text1 = `Attacking Target URL: ${values.targetIP}...`;
-        const text2 = "Check your netcat listener for a reverse shell...";
-
-        setText1(text1);
-        setText2(text2);
-
-        setHandle(newHandle);
-        setOutput(output);
-        setLoading(false);
-        setAllowSave(true);
+        CommandHelper.runCommandGetPidAndOutput("python3", args, handleProcessData, handleProcessTermination).then(
+            ({ pid: newPid }) => {
+                setPid(newPid);
+            }
+        );
     };
 
-    /**
-     * Kills the currently running exploit command if there is one.
-     */
-    const killHandle = async () => {
-        if (handle) {
-            await handle.kill();
-            setHandle(null);
-            setText1(null);
-            setText2(null);
-        }
-    };
-
-    /**
-     * Clears the output and resets save states.
-     */
     const clearOutput = useCallback(() => {
         setOutput("");
         setHasSaved(false);
         setAllowSave(false);
     }, [setOutput]);
 
-    /**
-     * Callback for handling the completion of the output save operation.
-     * Resets the save state to prevent duplicate saving.
-     */
     const handleSaveComplete = () => {
-        // Indicating that the file has saved which is passed
-        // back into SaveOutputToTextFile to inform the user
         setHasSaved(true);
         setAllowSave(false);
     };
-    /**
-     * Sends a SIGTERM signal to the child process to request a graceful termination.
-     */
+
     const handleCancel = () => {
-        if (pid !== null) {
-            const args = [`-15`, pid];
-            CommandHelper.runCommand("kill", args);
+        if (pid) {
+            CommandHelper.runCommand("kill", [`-15`, pid]);
+            setPid("");
+            setLoading(false);
         }
     };
 
@@ -217,6 +128,12 @@ export function CVE202224112() {
             tutorial={tutorial}
             sourceLink={sourceLink}
         >
+            <InstallationModal
+                isOpen={opened}
+                setOpened={setOpened}
+                feature_description={description}
+                dependencies={dependencies}
+            />
             <form onSubmit={form.onSubmit((values) => onSubmit(values))}>
                 <LoadingOverlay visible={loading} />
                 {loading && (
@@ -227,9 +144,10 @@ export function CVE202224112() {
                     </div>
                 )}
                 <Stack>
-                    <TextInput label={"IP or Hostname"} required {...form.getInputProps("hostIp")} />
+                    <TextInput label={"Host IP"} required {...form.getInputProps("hostIP")} />
+                    <TextInput label={"Target IP"} required {...form.getInputProps("targetIP")} />
                     <NumberInput label={"Port"} {...form.getInputProps("hostPort")} />
-                    <Button type={"submit"}>Scan</Button>
+                    <Button type={"submit"}>Exploit</Button>
                     {SaveOutputToTextFile_v2(output, allowSave, hasSaved, handleSaveComplete)}
                     <ConsoleWrapper output={output} clearOutputCallback={clearOutput} />
                 </Stack>
@@ -238,5 +156,4 @@ export function CVE202224112() {
     );
 }
 
-// Default export of the CVE202224112 component
 export default CVE202224112;


### PR DESCRIPTION
## Summary
This PR addresses two bugs found in the CVE-2022-24112 component.

## Bug 1 - Cancel Button Not Terminating Process (Empty PID)
The cancel button was sending kill -15 with an empty PID because the process ID was never stored after spawning. Fixed by replacing the duplicate Command.spawn() and CommandHelper.runCommand() calls with a single runCommandGetPidAndOutput() call which correctly captures and stores the PID.

## Bug 2 - Exploit Crashing Due to Invalid URL Formatting
The Python script was receiving a raw IP address instead of a properly formatted URL, causing an immediate MissingSchema crash. Fixed by formatting the target IP into a valid URL (http://<targetIP>:9080/) before passing it as an argument to the script.

## Testing
Cancel button was validated using a sleep process to confirm kill -15 correctly terminates the running process. URL fix was validated by confirming the script now attempts a proper HTTP connection rather than crashing immediately.

## Related Issues
Closes #1439 and #1647