### PR TITLE
Bug Fix #1610 - Unicornscan hanging: correct argument order and CommandHelper promise resolve.

### DIFF
--- a/src/components/Unicornscan/Unicornscan.tsx
+++ b/src/components/Unicornscan/Unicornscan.tsx
@@ -33,7 +33,7 @@ const Unicornscan = () => {
     const [pid, setPid] = useState("");
 
     // New state for dropdown selection
-    const [selectedScanType, setSelectedScanType] = useState("");
+    const [selectedScanType, setSelectedScanType] = useState("TCP Scan (-mT)");
     const [rate, setRate] = useState("");
     const [sourcePort, setSourcePort] = useState("");
     const [sourceIP, setSourceIP] = useState("");
@@ -117,34 +117,44 @@ const Unicornscan = () => {
      */
     const onSubmit = async (values: FormValuesType) => {
         setLoading(true);
-        let args = [values.targetIP];
 
-        // Add the selected scan type to the arguments
-        if (selectedScanType === "TCP Scan (-mT)") {
-            args.push("-mT");
-        } else if (selectedScanType === "UDP Scan (-mU)") {
-            args.push("-mU");
+        let args: string[] = [];
+
+        // Add interface first
+        if (interfaceName) {
+            args.push("-i", interfaceName);
+        } else {
+            args.push("-i", "eth0");
         }
 
-        // Include additional flags if they are set
-        if (rate) args.push(`-r ${rate}`);
-        if (sourcePort) args.push(`-e ${sourcePort}`);
-        if (sourceIP) args.push(`-g ${sourceIP}`);
-        if (interfaceName) args.push(`-i ${interfaceName}`);
-        if (ports) args.push(`-p ${ports}`);
+        // Add scan type
+        if (selectedScanType === "UDP Scan (-mU)") {
+            args.push("-mU");
+        } else {
+            args.push("-mT");
+        }
 
-        CommandHelper.runCommandWithPkexec("unicornscan", [...args, "-Iv"], handleProcessData, handleProcessTermination)
+        // Add optional flags as separate args
+        if (rate) args.push("-r", rate);
+        if (sourcePort) args.push("-s", sourcePort);
+        if (sourceIP) args.push("-g", sourceIP);
+
+        // Add target IP with optional ports at the end
+        const target = ports ? `${values.targetIP}:${ports}` : values.targetIP;
+        args.push(target);
+
+        // Add verbose flag last
+        args.push("-Iv");
+
+        CommandHelper.runCommandWithPkexec("unicornscan", args, handleProcessData, handleProcessTermination)
             .then(({ output, pid }) => {
-                // Update the UI with the results from the executed command
                 setOutput(output);
                 setAllowSave(true);
                 console.log(pid);
                 setPid(pid);
             })
             .catch((error) => {
-                // Display any errors encountered during command execution
                 setOutput(error.message);
-                // Deactivate loading state
                 setLoading(false);
                 setAllowSave(true);
             });

--- a/src/utils/CommandHelper.ts
+++ b/src/utils/CommandHelper.ts
@@ -128,7 +128,6 @@ export const CommandHelper = {
         onData: (data: string) => void,
         onTermination: ({ code, signal }: { code: number; signal: number }) => void
     ): Promise<{ pid: string; output: string }> {
-        // Modify how the command is prepared with 'pkexec'
         const command = new Command("pkexec", [commandString, ...args]);
         const handle: Child = await command.spawn();
         const pid = handle.pid.toString();
@@ -151,20 +150,19 @@ export const CommandHelper = {
             });
         }
 
+        // Only resolve once when the process actually closes
         return new Promise<{ pid: string; output: string }>((resolve, reject) => {
             command.on("close", ({ code, signal }: { code: number; signal: number }) => {
                 if (pid !== undefined) {
                     onTermination({ code, signal });
-                    resolve({ pid: pid, output: `${stdout}\n${stderr}` });
+                    resolve({
+                        pid: pid,
+                        output: `$ pkexec ${commandString} ${args.join(" ")}\n\n${stdout}\n${stderr}`,
+                    });
                 } else {
                     reject(new Error("Failed to get process PID."));
                 }
             });
-            if (pid !== undefined) {
-                resolve({ pid: pid, output: `$ pkexec ${commandString} ${args.join(" ")}\n\n${stdout}\n${stderr}` });
-            } else {
-                reject(new Error("Failed to get process PID."));
-            }
         });
     },
     /**


### PR DESCRIPTION
## Bug Fix: Unicornscan Hanging During Scan Execution

### Problem
Unicornscan would hang indefinitely when a scan was initiated due to:
- Incorrect argument order (IP first instead of interface)
- Wrong source port flag (-e instead of -s)
- Arguments bundled as single strings instead of separate values
- CommandHelper.runCommandWithPkexec resolving promise twice

### Fix
- Corrected argument order in onSubmit
- Fixed source port flag to -s
- Fixed CommandHelper to only resolve promise once on process close

## Known Limitation: Stale Socket Files

If the scan hangs on first run, it may be due to stale socket files from a previous unicornscan session.

### Workaround
1. Check for existing processes:
   ps aux | grep -E "unicornscan|unisend|unilisten"

2. Kill any found processes:
   sudo kill -9 <PID>

3. Clean up stale socket files:
   sudo rm -f /var/lib/unicornscan/send /var/lib/unicornscan/listen

4. Re-run the scan in DDT

## Fixed
#1610