### PR TITLE
Bug Fix #1466 output not readable

### DIFF
--- a/src/components/Fping/Fping.tsx
+++ b/src/components/Fping/Fping.tsx
@@ -221,9 +221,12 @@ function Fping() {
             if (checkedElapsed) {
                 args.push("-e");
             }
-            //Show the accumulated outage time.
-            if (checkedOutage) {
+           //Show the accumulated outage time.
+           if (checkedOutage) {
                 args.push("-o");
+                if (!values.count) {
+                args.push("-c", "1");
+            }
             }
             //Show quiet output.
             if (checkedQuiet) {


### PR DESCRIPTION
Description:
Addresses the GitHub bug report "[Bug]: output not readable". When "Show accumulated outage time" (-o) was enabled without a count set, fping produced no meaningful output. Added a default count of 1 to ensure meaningful output is always produced when -o is selected.

Proposed change:
Fping.tsx: Added default -c 1 when "Show accumulated outage time" is enabled and no count is specified