### PR TITLE
Fix #1684: Use consistent 'Manual Network Configuration' terminology …

### DIFF
--- a/src/components/BedTool/BEDTool.tsx
+++ b/src/components/BedTool/BEDTool.tsx
@@ -33,7 +33,7 @@ export function BEDTool() {
     const [selectedPlugin, setSelectedPlugin] = useState(""); // State variable to store the selected plugin.
     const [allowSave, setAllowSave] = useState(false); // State variable boolean to indicate save state.
     const [hasSaved, setHasSaved] = useState(false); // State variable boolean to indicate if the save has been saved.
-    const [customConfig, setCustomConfig] = useState(false); // State variable to toggle custom configuration.
+    const [customConfig, setCustomConfig] = useState(false); // State variable to toggle manual network configuration.
     const [isCommandAvailable, setIsCommandAvailable] = useState(false); // State variable to check if the command is available.
     const [opened, setOpened] = useState(!isCommandAvailable); // State variable that indicates if the modal is opened.
     const [loadingModal, setLoadingModal] = useState(true); // State variable to indicate loading state of the modal.
@@ -47,7 +47,7 @@ export function BEDTool() {
     const steps =
         '1. Select a Service: Choose the service to test from the dropdown menu, for instance, "HTTP" to test a web server.\n' +
         '2. Input Required Fields: Fill in the fields that appear based on the selected service. For example, choosing "FTP" will prompt for additional required fields, such as username and password.\n' +
-        "3. Custom Configuration (Optional): Activate 'Custom Configuration' to enter a specific target IP address and port number. If this is not enabled, the tool will default to scanning the local machine.\n" +
+        "3. Manual Network Configuration (Optional): Activate 'Manual Network Configuration' to enter a specific target IP address and port number. If this is not enabled, the tool will default to scanning the local machine.\n" +
         "4. Start Scan: Click the 'Scan' button to begin the evaluation.";
     const sourceLink = "https://www.kali.org/tools/bed/"; // Link to the source documentation.
     const tutorial = "https://hackmd.io/@zee-10/ryfv2IOSWl"; // Link to the official documentation/tutorial.
@@ -258,7 +258,7 @@ export function BEDTool() {
                         onChange={(e) => setCustomConfig(e.currentTarget.checked)}
                     />
                     {customConfig && (
-                        <Alert title="Custom Configuration" color="blue" variant="light">
+                        <Alert title="Manual Network Configuration" color="blue" variant="light">
                             Custom IP address and port can now be specified for this scan. Leave these fields blank to
                             use default settings.
                         </Alert>


### PR DESCRIPTION
## Description
Fixes #1684 - standardizes terminology for BEDTool's network configuration option.

Previously, the Configuration tab correctly labeled the toggle "Manual Network Configuration," but the Alert info panel and the User Guide step-by-step instructions referred to the same feature as "Custom Configuration." This inconsistency could confuse users into thinking these were separate settings.

## Changes
- Updated the Alert panel title from "Custom Configuration" to "Manual Network Configuration"
- Updated User Guide step 3 text to use "Manual Network Configuration"
- Updated an internal code comment for consistency

## Testing
- Verified in the running app: toggling "Manual Network Configuration" now shows a matching "Manual Network Configuration" info panel
- Verified User Guide tab now displays consistent wording
- Verified Tutorial tab wording (screenshot attached, if applicable)

## Screenshots
Before / After attached

User Guide (before)

<img width="959" height="599" alt="user guide tab bed tool before" src="https://github.com/user-attachments/assets/b179e263-27e9-4c90-9b6c-99e1c0e9e458" />

Configuration toggle OFF (before)

<img width="959" height="595" alt="config tab manual off before" src="https://github.com/user-attachments/assets/6fa1a0c0-8872-4394-aaeb-a685e9d0ad01" />

Configuration toggle ON, Alert = "Custom Configuration" (before)
<img width="959" height="599" alt="config tab bed tool before" src="https://github.com/user-attachments/assets/3808207d-f974-4167-96f8-9e2d56320e8b" />

Configuration toggle ON, Alert = "Manual Network Configuration" (after)

<img width="959" height="599" alt="manual network config after" src="https://github.com/user-attachments/assets/93dd7fa7-5437-4ab6-8577-002cefbe1c39" />

User Guide (after)

<img width="952" height="596" alt="user guide after" src="https://github.com/user-attachments/assets/aa81f96b-dfcd-46c6-8f95-2ca0867b54df" />






