### PR TITLE
Update Sherlock tutorial (#1714)

### DIFF
--- a/src/components/Sherlock/Sherlock.tsx
+++ b/src/components/Sherlock/Sherlock.tsx
@@ -46,7 +46,7 @@ const Sherlock = () => {
         "Step 2: Click Start Searching to commence Sherlock's operation.\n\n" +
         "Step 3: View the Output block below to view the results of the tool's execution.";
     const sourceLink = "https://www.kali.org/tools/sherlock/";
-    const tutorial = "https://docs.google.com/document/d/13P51Pa0k0NUEV0FNueRp4mAUjvc2mLNatKkrlkIcz20/edit?usp=sharing"; // No specific tutorial URL available
+    const tutorial = "https://drive.google.com/file/d/1AhBbBRT5lKdx3dNz3n-RBGkG4G9xjquE/preview";
     const dependencies = ["sherlock"]; // Contains required dependencies
 
     // Form hook to manage form input


### PR DESCRIPTION
Updated the Sherlock tutorial link to a new step-by-step guide covering:

- Basic username search
- Search output
- Advanced mode options
- Site-specific searching
- Saving and clearing results
- Troubleshooting

Tested successfully in DDT.

Fixes #1714