### PR TITLE
fix(sqlmap): add input validation to session cookie field (#1759)

### DIFF
--- a/src/components/SQLmap/SQLmap.tsx
+++ b/src/components/SQLmap/SQLmap.tsx
@@ -27,6 +27,53 @@ interface FormValuesType {
 }
 
 /**
+ * Validates the session cookie string for SQLMap.
+ * Accepts an empty string (optional field) or valid cookie format:
+ * one or more name=value pairs separated by semicolons.
+ *
+ * @param {string} cookie - The session cookie string to validate.
+ * @returns {string | null} Error message if invalid, null if valid.
+ */
+export const validateSessionCookie = (cookie: string): string | null => {
+    const trimmed = (cookie || "").trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    // Must not start or end with a semicolon
+    if (trimmed.startsWith(";") || trimmed.endsWith(";")) {
+        return "Invalid cookie format. Expected name=value pairs separated by semicolons (e.g., PHPSESSID=abc123; security=low)";
+    }
+
+    // Split into individual cookie pairs separated by ';'
+    const pairs = trimmed.split(";");
+
+    for (const rawPair of pairs) {
+        const pair = rawPair.trim();
+        // Empty pair (e.g. consecutive semicolons like 'a=b;;c=d')
+        if (!pair) {
+            return "Invalid cookie format. Expected name=value pairs separated by semicolons (e.g., PHPSESSID=abc123; security=low)";
+        }
+
+        const equalIndex = pair.indexOf("=");
+        // Must contain '=' and name must not be empty
+        if (equalIndex <= 0) {
+            return "Invalid cookie format. Expected name=value pairs separated by semicolons (e.g., PHPSESSID=abc123; security=low)";
+        }
+
+        const name = pair.slice(0, equalIndex).trim();
+        const value = pair.slice(equalIndex + 1).trim();
+
+        // Name and value must not be empty, and name must not contain whitespace
+        if (!name || !value || /\s/.test(name)) {
+            return "Invalid cookie format. Expected name=value pairs separated by semicolons (e.g., PHPSESSID=abc123; security=low)";
+        }
+    }
+
+    return null;
+};
+
+/**
  * The SQLmap component.
  * @returns The SQLmap component.
  */
@@ -58,7 +105,7 @@ function SQLmap() {
     const dependencies = ["sqlmap"];
 
     // Form hook to handle form input
-    const form = useForm({
+    const form = useForm<FormValuesType>({
         initialValues: {
             targetURL: "",
             detectionLevel: "1",
@@ -72,6 +119,9 @@ function SQLmap() {
             banner: false,
             dbs: false,
             passwords: false,
+        },
+        validate: {
+            sessionCookie: validateSessionCookie,
         },
     });
 
@@ -118,6 +168,10 @@ function SQLmap() {
      * Handles form submission for SQLMap.
      */
     const onSubmit = async (values: FormValuesType) => {
+        if (form.validate().hasErrors) {
+            return;
+        }
+
         setLoading(true);
 
         // Base SQLMap arguments
@@ -127,7 +181,7 @@ function SQLmap() {
         // If a cookie was supplied, pass it to SQLMap.
         // This enables testing authenticated targets.
         if (values.sessionCookie.trim() !== "") {
-            args.push(`--cookie=${values.sessionCookie}`);
+            args.push(`--cookie=${values.sessionCookie.trim()}`);
         }
 
         if (values.banner) {


### PR DESCRIPTION
## Description
Resolves #1759.

Follow-up to #1614. The Session Cookie field added in that fix works correctly for well-formed values, but previously lacked input validation, allowing clearly malformed strings (e.g., `test` lacking a `name=value` structure, or `login=test/test';` containing a trailing semicolon) to be accepted and passed directly to SQLMap without any DDT-level warning or prevention.

### Summary of Changes
- **Validation Logic**: Added a `validateSessionCookie` helper function to validate cookie input:
  - Accepts empty or whitespace-only values since the Session Cookie field is optional.
  - Verifies that input consists of valid `name=value` cookie pairs separated by semicolons (e.g., `PHPSESSID=abc123; security=low`).
  - Rejects inputs without `name=value` pairs (e.g., `test`), missing names or values, empty pairs, and leading or trailing semicolons (e.g., `login=test/test';`).
  - Correctly permits cookie values containing special characters, slashes, or base64 padding (e.g., `token=abc==; id=123`).
- **Form Integration**: Wired `validateSessionCookie` into Mantine's `useForm` validation for the `sessionCookie` field:
  - Displays an inline warning under the Session Cookie field if input is malformed.
  - Halts submission in `onSubmit` if validation errors are present, preventing the scan from starting with invalid cookies.
- **Argument Trimming**: Ensured `values.sessionCookie.trim()` is passed to `--cookie` so accidental outer whitespace is stripped.

## Testing Evidence
- Locally verified the validation logic across all edge cases including valid formats (empty input, single pair, multiple pairs, base64 values, special characters) and invalid formats (missing name=value pairs, trailing semicolon, leading semicolon, empty pairs, spaces in names).
- Verified `yarn run style` passes with Prettier formatting.
- Verified production build succeeds (`yarn run build`).
- Verified existing test suite passes (`yarn test`).

Closes #1759
