### PR TITLE
Fix WhatWeb input file target processing

### DIFF
--- a/src/components/WhatWeb/WhatWeb.tsx
+++ b/src/components/WhatWeb/WhatWeb.tsx
@@ -22,6 +22,7 @@ import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/Overlay
 import { checkAllCommandsAvailability } from "../../utils/CommandAvailability";
 import InstallationModal from "../InstallationModal/InstallationModal";
 import { RenderComponent } from "../UserGuide/UserGuide";
+import { open } from "@tauri-apps/plugin-dialog";
 
 /**
  * Represents the form values for the WhatWeb component.
@@ -171,6 +172,17 @@ function WhatWeb() {
         setAllowSave(false);
     };
 
+    const pickInputFile = async () => {
+        const selected = await open({
+            filters: [{ name: "Text File", extensions: ["txt"] }],
+            multiple: false,
+        });
+
+        if (typeof selected === "string") {
+            form.setFieldValue("inputFile", selected);
+        }
+    };
+
     // Submit handler
     const onSubmit = async (values: FormValuesType) => {
         if (!values.target.trim() && !values.inputFile.trim()) {
@@ -185,6 +197,7 @@ function WhatWeb() {
 
         const args: string[] = [];
         if (values.inputFile) args.push("-i", values.inputFile);
+
         if (values.aggression) args.push("-a", values.aggression);
         if (values.userAgent) args.push("-U", values.userAgent);
         if (values.followRedirect) args.push(`--follow-redirect=${values.followRedirect}`);
@@ -194,7 +207,10 @@ function WhatWeb() {
         if (values.verbose) args.push("-v");
         if (values.logFormat) args.push(`--log-${values.logFormat}=-`);
         if (values.maxThreads > 0) args.push("-t", String(values.maxThreads));
-        args.push(values.target);
+
+        if (values.target.trim()) {
+            args.push(values.target.trim());
+        }
 
         try {
             const { pid, output } = await CommandHelper.runCommandGetPidAndOutput(
@@ -315,7 +331,14 @@ function WhatWeb() {
                             {/* Step 1 */}
                             <Stepper.Step label="Target">
                                 <TextInput label="Target URL or IP" required {...form.getInputProps("target")} />
-                                <TextInput label="Input File" {...form.getInputProps("inputFile")} />
+                                <Group align="end">
+                                    <TextInput
+                                        label="Input File"
+                                        style={{ flex: 1 }}
+                                        {...form.getInputProps("inputFile")}
+                                    />
+                                    <Button onClick={pickInputFile}>Browse</Button>
+                                </Group>
                                 <Group mt={20} position="right">
                                     <Button onClick={nextStep}>Next</Button>
                                 </Group>


### PR DESCRIPTION
Fixes #1723

This PR fixes WhatWeb input file target processing by correctly passing the selected input file to WhatWeb using the -i argument. It also prevents an empty target value from being added when the user is using an input file only.

As an additional usability improvement, a Browse button was added so users can select a .txt input file directly instead of manually entering the full file path.

Testing confirmed that WhatWeb successfully reads the selected file and scans the target, returning a 200 OK result.