### PR TITLE
Add 'foremost' command to migrated.json

### DIFF
--- a/src-tauri/capabilities/migrated.json
+++ b/src-tauri/capabilities/migrated.json
@@ -187,6 +187,12 @@
         },
         {
           "args": true,
+          "cmd": "foremost",
+          "name": "foremost",
+          "sidecar": false
+        },
+        {
+          "args": true,
           "cmd": "ffuf",
           "name": "ffuf",
           "sidecar": false
@@ -662,6 +668,12 @@
           "args": true,
           "cmd": "fcrackzip",
           "name": "fcrackzip",
+          "sidecar": false
+        },
+        {
+          "args": true,
+          "cmd": "foremost",
+          "name": "foremost",
           "sidecar": false
         },
         {


### PR DESCRIPTION
Addressed the review feedback by implementing the Foremost permission through the Tauri capabilities system in src-tauri/capabilities/migrated.json. Added Foremost to both shell:allow-execute and shell:allow-spawn, consistent with the existing tool configuration pattern. This supersedes the previous tauri.conf.json approach used in #1703 and is covered in #1763.