### PR TITLE
fix(sherlock): prevent restart on repeated search

### DIFF
--- a/src/components/Sherlock/Sherlock.tsx
+++ b/src/components/Sherlock/Sherlock.tsx
@@ -1,5 +1,6 @@
 import { Button, Checkbox, Stack, TextInput, Switch } from "@mantine/core";
 import { useForm } from "@mantine/form";
+import { appCacheDir } from "@tauri-apps/api/path";
 import { useCallback, useState } from "react";
 import { CommandHelper } from "../../utils/CommandHelper";
 import ConsoleWrapper from "../ConsoleWrapper/ConsoleWrapper";
@@ -8,15 +9,7 @@ import { SaveOutputToTextFile_v2 } from "../SaveOutputToFile/SaveOutputToTextFil
 import { LoadingOverlayAndCancelButton } from "../OverlayAndCancelButton/OverlayAndCancelButton";
 import AskChatGPT from "../AskChatGPT/AskChatGPT";
 import ChatGPTOutput from "../AskChatGPT/ChatGPTOutput";
-
-/**
- * Represents the form values for the Sherlock component.
- */
-interface FormValuesType {
-    username: string;
-    site: string;
-    timeout: number;
-}
+import { buildSherlockArgs, type SherlockFormValues } from "./sherlockArgs";
 
 /**
  * The Sherlock Component
@@ -108,29 +101,23 @@ const Sherlock = () => {
     /**
      * onSubmit: Asynchronous handler for form submission.
      * Triggers the sherlock tool with provided parameters.
-     * @param {FormValuesType} values - The form values containing the username(s), site, and timeout.
+     * @param {SherlockFormValues} values - The form values containing the username(s), site, and timeout.
      */
-    const onSubmit = async (values: FormValuesType) => {
+    const onSubmit = async (values: SherlockFormValues) => {
         // Activate loading state
         setLoading(true);
         // Disallow saving until tool execution is complete
         setAllowSave(false);
 
-        // Construct arguments for Sherlock tool
-        const args = [];
-        if (checkedVerbose) {
-            args.push("--verbose");
-        }
-        if (values.site) {
-            args.push("--site", `${values.site}`);
-        }
-        if (values.timeout) {
-            args.push("--timeout", `${values.timeout}`);
-        }
-        args.push(...values.username.split(" "));
-
         // Run the Sherlock tool using the helper method
         try {
+            const outputDirectory = await appCacheDir();
+            // Sherlock creates --folderoutput itself; no Tauri filesystem access is needed.
+            const args = buildSherlockArgs(values, {
+                verbose: checkedVerbose,
+                outputDirectory,
+            });
+
             const result = await CommandHelper.runCommandGetPidAndOutput(
                 "sherlock",
                 args,
@@ -139,8 +126,8 @@ const Sherlock = () => {
             );
             setPid(result.pid); // Set process ID
             setOutput(result.output); // Set command output
-        } catch (e: any) {
-            setOutput(e.message); // Display error message if command execution fails
+        } catch (e: unknown) {
+            setOutput(`Unable to start Sherlock: ${e instanceof Error ? e.message : String(e)}`);
             setLoading(false); // Stop loading
         }
     };

--- a/src/components/Sherlock/sherlockArgs.ts
+++ b/src/components/Sherlock/sherlockArgs.ts
@@ -1,0 +1,34 @@
+export interface SherlockFormValues {
+    username: string;
+    site: string;
+    timeout: number;
+}
+
+interface SherlockOptions {
+    verbose: boolean;
+    outputDirectory: string;
+}
+
+/**
+ * Build arguments that work with the Sherlock version packaged by Kali.
+ *
+ * Sherlock 0.14.x always writes a text file. Keeping that output in the app
+ * cache prevents the Tauri development watcher from restarting DDT when a
+ * previously searched username is used again.
+ */
+export function buildSherlockArgs(values: SherlockFormValues, options: SherlockOptions): string[] {
+    const args = ["--local", "--folderoutput", options.outputDirectory];
+
+    if (options.verbose) {
+        args.push("--verbose");
+    }
+    if (values.site) {
+        args.push("--site", values.site);
+    }
+    if (values.timeout) {
+        args.push("--timeout", `${values.timeout}`);
+    }
+
+    args.push(...values.username.trim().split(/\s+/));
+    return args;
+}


### PR DESCRIPTION
## Description

Fixes #1719.

Sherlock was causing DDT to restart when the same username was searched again.

The problem was caused by Sherlock writing output inside the project directory. In development mode, this could trigger the file watcher and reload the application.

## Changes

- Moved Sherlock output to the OS app cache directory.
- Prevented repeated searches from triggering a DDT restart.
- Extracted Sherlock argument construction into `sherlockArgs.ts`.
- Improved handling of Sherlock process spawn errors.

## Testing

Tested repeated searches using the same username


<img width="1909" height="1010" alt="beforepng" src="https://github.com/user-attachments/assets/470e583e-1dec-4cd1-b1d2-0d1a9d297cbf" />
After 
<img width="1909" height="1015" alt="after" src="https://github.com/user-attachments/assets/3f533158-41f9-4b2a-b083-091f88670bd9" />

Closes #1719Before